### PR TITLE
[feat] 도시 도메인 엔티티 및 기본 crud 로직 구현

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityController.java
@@ -1,0 +1,54 @@
+package com.haejwo.tripcometrue.domain.city.controller;
+
+import com.haejwo.tripcometrue.domain.city.dto.request.AddCityRequestDto;
+import com.haejwo.tripcometrue.domain.city.dto.response.CityResponseDto;
+import com.haejwo.tripcometrue.domain.city.service.CityService;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/cities")
+@RestController
+public class CityController {
+
+    private final CityService cityService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<CityResponseDto>> addCity(
+        @RequestBody AddCityRequestDto request
+    ) {
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(
+                ResponseDTO.okWithData(cityService.addCity(request))
+            );
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ResponseDTO<CityResponseDto>> findCity(
+        @PathVariable("id") Long id
+    ) {
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(
+                ResponseDTO.okWithData(cityService.findCity(id))
+            );
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResponseDTO<Void>> deleteCity(
+        @PathVariable("id") Long id
+    ) {
+
+        cityService.deleteCity(id);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ResponseDTO.ok());
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/request/AddCityRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/request/AddCityRequestDto.java
@@ -1,0 +1,30 @@
+package com.haejwo.tripcometrue.domain.city.dto.request;
+
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.global.enums.Country;
+
+public record AddCityRequestDto(
+    String name,
+    String language,
+    String timeDifference,
+    String voltage,
+    String visa,
+    String currency,
+    String weatherRecommendation,
+    String weatherDescription,
+    Country country
+) {
+    public City toEntity() {
+        return City.builder()
+            .name(this.name)
+            .language(this.language)
+            .timeDifference(this.timeDifference)
+            .voltage(this.voltage)
+            .visa(this.visa)
+            .currency(this.currency)
+            .weatherRecommendation(this.weatherRecommendation)
+            .weatherDescription(this.weatherDescription)
+            .country(this.country)
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
@@ -1,0 +1,31 @@
+package com.haejwo.tripcometrue.domain.city.dto.response;
+
+import com.haejwo.tripcometrue.domain.city.entity.City;
+
+public record CityResponseDto(
+    Long id,
+    String name,
+    String language,
+    String timeDifference,
+    String voltage,
+    String visa,
+    String currency,
+    String weatherRecommendation,
+    String weatherDescription,
+    String country
+) {
+    public static CityResponseDto fromEntity(City entity) {
+        return new CityResponseDto(
+            entity.getId(),
+            entity.getName(),
+            entity.getLanguage(),
+            entity.getTimeDifference(),
+            entity.getVoltage(),
+            entity.getVisa(),
+            entity.getCurrency(),
+            entity.getWeatherRecommendation(),
+            entity.getWeatherDescription(),
+            entity.getCountry().getDescription()
+        );
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
@@ -1,0 +1,50 @@
+package com.haejwo.tripcometrue.domain.city.entity;
+
+import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
+import com.haejwo.tripcometrue.global.enums.Country;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class City extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "city_id")
+    private Long id;
+    private String name;
+    private String language;
+    private String timeDifference;
+    private String voltage;
+    private String visa;
+    private String currency;
+    private String weatherRecommendation;
+    private String weatherDescription;
+
+    @Enumerated(EnumType.STRING)
+    private Country country;
+
+    @Builder
+    private City(
+        Long id, String name, String language, String timeDifference,
+        String voltage, String visa, String currency, String weatherRecommendation,
+        String weatherDescription, Country country
+    ) {
+        this.id = id;
+        this.name = name;
+        this.language = language;
+        this.timeDifference = timeDifference;
+        this.voltage = voltage;
+        this.visa = visa;
+        this.currency = currency;
+        this.weatherRecommendation = weatherRecommendation;
+        this.weatherDescription = weatherDescription;
+        this.country = country;
+    }
+}
+

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/exception/CityNotFoundException.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/exception/CityNotFoundException.java
@@ -1,0 +1,13 @@
+package com.haejwo.tripcometrue.domain.city.exception;
+
+import com.haejwo.tripcometrue.global.exception.ApplicationException;
+import com.haejwo.tripcometrue.global.exception.ErrorCode;
+
+public class CityNotFoundException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.CITY_NOT_FOUND;
+
+    public CityNotFoundException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepository.java
@@ -1,0 +1,7 @@
+package com.haejwo.tripcometrue.domain.city.repository;
+
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CityRepository extends JpaRepository<City, Long> {
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityService.java
@@ -1,0 +1,40 @@
+package com.haejwo.tripcometrue.domain.city.service;
+
+import com.haejwo.tripcometrue.domain.city.dto.request.AddCityRequestDto;
+import com.haejwo.tripcometrue.domain.city.dto.response.CityResponseDto;
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.exception.CityNotFoundException;
+import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CityService {
+
+    private final CityRepository cityRepository;
+
+    @Transactional
+    public CityResponseDto addCity(AddCityRequestDto request) {
+        return CityResponseDto.fromEntity(
+            cityRepository.save(request.toEntity())
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public CityResponseDto findCity(Long id) {
+        return CityResponseDto.fromEntity(
+            cityRepository.findById(id)
+                .orElseThrow(CityNotFoundException::new)
+        );
+    }
+
+    @Transactional
+    public void deleteCity(Long id) {
+        City city = cityRepository.findById(id)
+            .orElseThrow(CityNotFoundException::new);
+
+        cityRepository.delete(city);
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/enums/Continent.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/enums/Continent.java
@@ -1,0 +1,18 @@
+package com.haejwo.tripcometrue.global.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Continent {
+
+    ASIA("아시아"),
+    AFRICA("아프리카"),
+    AMERICA("아메리카"),
+    EUROPE("유럽"),
+    OCEANIA("오세아니아"),
+    KOREA("대한민국");
+
+    private final String description;
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/enums/Country.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/enums/Country.java
@@ -1,0 +1,30 @@
+package com.haejwo.tripcometrue.global.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Country {
+
+    KOREA("대한민국", Continent.KOREA),
+    JAPAN("일본", Continent.ASIA),
+    THAILAND("태국", Continent.ASIA),
+    INDONESIA("인도네시아", Continent.ASIA),
+    SINGAPORE("싱가포르", Continent.ASIA),
+
+    USA("미국", Continent.AMERICA),
+    CANADA("캐나다", Continent.AMERICA),
+
+    FRANCE("프랑스", Continent.EUROPE),
+    UNITED_KINGDOM("영국", Continent.EUROPE),
+    ITALIA("이탈리아", Continent.EUROPE),
+    GERMANY("독일", Continent.EUROPE),
+
+    GUAM("괌", Continent.OCEANIA),
+    NEW_ZEALAND("뉴질랜드", Continent.OCEANIA),
+    AUSTRALIA("호주", Continent.OCEANIA);
+
+    private final String description;
+    private final Continent continent;
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
@@ -23,6 +23,9 @@ public enum ErrorCode {
     // AUTH
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다."),
 
+    // CITY
+    CITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 도시입니다."),
+
     // PLACE
     PLCAE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행지입니다."),
 


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)
- [ ] 리팩토링 (Refactoring)
- [ ] 버그 수정 (Bug Fix)
- [ ] 테스트 (Test)
- [ ] CI/CD
- [ ] 설정 (Setup)

- **간략한 설명**:
  : 도시 도메인의 엔티티를 생성하고 도시 생성/단일 조회/삭제 기능을 구현합니다.

---

## 🛠 작성/변경 사항

- ### 주요작성
- 도시 엔티티 추가
- 도시 레포지토리 추가
- 도시 서비스 추가
- 도시 컨트롤러 추가
---

## 🔗 관련 이슈

- **이슈 링크** : #27 

---

## 💡 특이 사항

- **주목할 사항** 
  - global 패키지 하위 enums 패키지를 생성해 공통적으로 사용될 Enum 클래스를 추가했습니다.
     - Country 
     - Continent

---

## 🧪 테스트

- **테스트 계획 및 결과** 
  - 추후 서비스/컨트롤러 테스트 작성 예정
  
---

This close #27 
