### PR TITLE
[feat] 여행후기 상세조회 페이지 1차 구현 완료

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
@@ -41,10 +41,11 @@ public class TripRecordController {
 
     @GetMapping("/{tripRecordId}")
     public ResponseEntity<ResponseDTO<TripRecordDetailResponseDto>> tripRecordDetail(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
         @PathVariable Long tripRecordId
     ) {
 
-        TripRecordDetailResponseDto responseDto = tripRecordService.findTripRecord(tripRecordId);
+        TripRecordDetailResponseDto responseDto = tripRecordService.findTripRecord(principalDetails, tripRecordId);
         ResponseDTO<TripRecordDetailResponseDto> responseBody = ResponseDTO.okWithData(responseDto);
 
         return ResponseEntity

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/TripRecordScheduleDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/TripRecordScheduleDto.java
@@ -1,0 +1,33 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto;
+
+import com.haejwo.tripcometrue.domain.place.entity.Place;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+
+public record TripRecordScheduleDto(
+    Long id,
+    Integer dayNumber,
+    Integer ordering,
+    String content,
+    TripRecord tripRecord,
+    Place place
+) {
+
+    @Builder
+    public TripRecordScheduleDto(Long id, Integer dayNumber, Integer ordering, String content,
+        TripRecord tripRecord, Place place) {
+        this.id = id;
+        this.dayNumber = dayNumber;
+        this.ordering = ordering;
+        this.content = content;
+        this.tripRecord = tripRecord;
+        this.place = place;
+    }
+
+
+
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/member/TripRecordMemberResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/member/TripRecordMemberResponseDto.java
@@ -5,19 +5,19 @@ import lombok.Builder;
 
 public record TripRecordMemberResponseDto(
     String nickname,
-    String profile_image
+    String profileImage
 ) {
 
     @Builder
-    public TripRecordMemberResponseDto(String nickname, String profile_image) {
+    public TripRecordMemberResponseDto(String nickname, String profileImage) {
         this.nickname = nickname;
-        this.profile_image = profile_image;
+        this.profileImage = profileImage;
     }
 
     public static TripRecordMemberResponseDto formEntity(Member entity) {
         return TripRecordMemberResponseDto.builder()
             .nickname(entity.getMemberBase().getNickname())
-            .nickname(entity.getProfile_image())
+            .profileImage(entity.getProfile_image())
             .build();
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule/TripRecordScheduleDetailResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule/TripRecordScheduleDetailResponseDto.java
@@ -13,7 +13,7 @@ public record TripRecordScheduleDetailResponseDto(
     Integer dayNumber,
     Integer ordering,
     String content,
-    Long memberId,
+    Long placeId,
     Long tripRecordId,
     List<TripRecordScheduleImageResponseDto> images,
     List<TripRecordScheduleVideoResponseDto> videos
@@ -21,14 +21,14 @@ public record TripRecordScheduleDetailResponseDto(
 
     @Builder
     public TripRecordScheduleDetailResponseDto(Long id, Integer dayNumber, Integer ordering,
-        String content, Long memberId, Long tripRecordId,
+        String content, Long placeId, Long tripRecordId,
         List<TripRecordScheduleImageResponseDto> images,
         List<TripRecordScheduleVideoResponseDto> videos) {
         this.id = id;
         this.dayNumber = dayNumber;
         this.ordering = ordering;
         this.content = content;
-        this.memberId = memberId;
+        this.placeId = placeId;
         this.tripRecordId = tripRecordId;
         this.images = images;
         this.videos = videos;
@@ -51,7 +51,7 @@ public record TripRecordScheduleDetailResponseDto(
             .dayNumber(entity.getDayNumber())
             .ordering(entity.getOrdering())
             .content(entity.getContent())
-            .memberId(entity.getMember() != null ? entity.getMember().getId() : null)
+            .placeId(entity.getPlaceId())
             .tripRecordId(entity.getTripRecord() != null ? entity.getTripRecord().getId() : null)
             .images(imageDtos)
             .videos(videoDtos)

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecord.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecord.java
@@ -97,9 +97,18 @@ public class TripRecord extends BaseTimeEntity {
         this.countries = requestDto.countries();
     }
 
+    public void incrementViewCount() {
+        if(this.viewCount == null) {
+            this.viewCount = 1;
+        } else {
+            this.viewCount++;
+        }
+    }
+
     @PrePersist
     public void prePersist() {
         this.totalDays = calculateTotalDays();
+        this.viewCount = 0;
     }
 
     @PreUpdate

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordImage.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordImage.java
@@ -27,6 +27,7 @@ public class TripRecordImage extends BaseTimeEntity {
     @Column(name = "trip_record_image_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     private TripRecordImageType imageType;
     private String imageUrl;
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordSchedule.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordSchedule.java
@@ -1,6 +1,5 @@
 package com.haejwo.tripcometrue.domain.triprecord.entity;
 
-import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -36,28 +35,29 @@ public class TripRecordSchedule extends BaseTimeEntity {
 
     private String content;
 
+    private Long placeId;
+
+    @ManyToOne
+    @JoinColumn(name = "tripRecord_id")
+    private TripRecord tripRecord;
+
     @OneToMany(mappedBy = "tripRecordSchedule", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<TripRecordScheduleImage> tripRecordScheduleImages = new ArrayList<>();
 
     @OneToMany(mappedBy = "tripRecordSchedule", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<TripRecordScheduleVideo> tripRecordScheduleVideos = new ArrayList<>();
 
-    @ManyToOne
-    @JoinColumn(name = "tripRecord_id")
-    private TripRecord tripRecord;
-
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
-
     @Builder
     public TripRecordSchedule(Long id, Integer dayNumber, Integer ordering, String content,
-        TripRecord tripRecord, Member member) {
+        Long placeId, TripRecord tripRecord, List<TripRecordScheduleImage> tripRecordScheduleImages,
+        List<TripRecordScheduleVideo> tripRecordScheduleVideos) {
         this.id = id;
         this.dayNumber = dayNumber;
         this.ordering = ordering;
         this.content = content;
+        this.placeId = placeId;
         this.tripRecord = tripRecord;
-        this.member = member;
+        this.tripRecordScheduleImages = tripRecordScheduleImages;
+        this.tripRecordScheduleVideos = tripRecordScheduleVideos;
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordViewCount.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordViewCount.java
@@ -8,7 +8,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,8 +25,25 @@ public class TripRecordViewCount extends BaseTimeEntity {
 
     private Integer viewCount;
 
+    private LocalDate date;
+
     @ManyToOne
     @JoinColumn(name = "trip_record_id")
     private TripRecord tripRecord;
 
+    @Builder
+    public TripRecordViewCount(Long id, Integer viewCount, LocalDate date, TripRecord tripRecord) {
+        this.id = id;
+        this.viewCount = viewCount;
+        this.date = date;
+        this.tripRecord = tripRecord;
+    }
+
+    public void incrementViewCount() {
+        if(this.viewCount == null) {
+            this.viewCount = 1;
+        } else {
+            this.viewCount++;
+        }
+    }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/TripRecordViewCountRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/TripRecordViewCountRepository.java
@@ -1,0 +1,13 @@
+package com.haejwo.tripcometrue.domain.triprecord.repository;
+
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewCount;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRecordViewCountRepository extends JpaRepository<TripRecordViewCount, Long> {
+
+    Optional<TripRecordViewCount> findByTripRecordAndDate(TripRecord tripRecord, LocalDate date);
+
+}


### PR DESCRIPTION
## 🎯 목적

- [X] 새 기능 (New Feature)
- [ ] 리팩토링 (Refactoring)
- [ ] 버그 수정 (Bug Fix)
- [ ] 테스트 (Test)
- [ ] CI/CD
- [ ] 설정 (Setup)

- **간략한 설명**:
  : 여행 후기 상세조회 페이지에 대한 1차 구현이 완료되었다. 현재 당장 필요하다고 생각되는 정보는 모두 응답으로 출력되는것으로 확인된다.

---

## 🛠 작성/변경 사항

- **(주요작성/변경사항)**
- schedule 엔티티 스프링 내에서 place 과의 관계를 매핑하지 않고 암시적 관계로서 place_id만 가지고 있는 것으로 수정
- 여행 후기 상세조회 시, 해당 여행후기 정보(이미지, 태그 포함)과 관련 스케쥴을 한번에 보내 주도록 구현

---

## 🔗 관련 이슈

- **이슈 링크1** : #53 

---

## 💡 특이 사항

- **주목할 사항** 
  - schedule 엔티티 place 매핑관계 해제
  - 

---

## 📖 문서화

- **관련 문서 링크** 
  - (링크1)
  - 
---

## 🧪 테스트

- **테스트 계획 및 결과** 
  - (테스트계획)
  - (테스트결과)

---

## 📚 참조

- **참조 링크**
  - (링크1)
 
- **참고 자료**
  - (자료1)
