### PR TITLE
[feat] 마이페이지/ 최근에 본 후기 기능 1차 구현

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordViewHistory.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordViewHistory.java
@@ -1,16 +1,18 @@
 package com.haejwo.tripcometrue.domain.triprecord.entity;
-
-
 import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,16 +21,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripRecordViewHistory extends BaseTimeEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "trip_record_view_history")
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "trip_record_view_history")
+  private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
 
-    @ManyToOne
-    @JoinColumn(name = "trip_record_id")
-    private TripRecord tripRecord;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "trip_record_id")
+  private TripRecord tripRecord;
+
+  @PreUpdate
+  public void updateUpdatedAt() {
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  @Builder
+  public TripRecordViewHistory(Member member, TripRecord tripRecord) {
+    this.member = member;
+    this.tripRecord = tripRecord;
+  }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -1,6 +1,6 @@
 package com.haejwo.tripcometrue.domain.triprecord.service;
+
 import com.haejwo.tripcometrue.domain.member.exception.UserInvalidAccessException;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.ModelAttribute.TripRecordListRequestAttribute;
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.TripRecordRequestDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
@@ -8,6 +8,9 @@ import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRec
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewCount;
 import com.haejwo.tripcometrue.domain.triprecord.exception.TripRecordNotFoundException;
+import com.haejwo.tripcometrue.domain.triprecord.repository.TripRecordRepository;
+import com.haejwo.tripcometrue.domain.triprecord.repository.TripRecordViewCountRepository;
+import com.haejwo.tripcometrue.domain.triprecordViewHistory.service.TripRecordViewHistoryService;
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord.TripRecordRepository;
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_viewcount.TripRecordViewCountRepository;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
@@ -26,6 +29,7 @@ public class TripRecordService {
 
     private final TripRecordRepository tripRecordRepository;
     private final TripRecordViewCountRepository tripRecordViewCountRepository;
+    private final TripRecordViewHistoryService tripRecordViewHistoryService;
 
 
     @Transactional
@@ -36,6 +40,7 @@ public class TripRecordService {
 
         if(memberId != findTripRecord.getMember().getId()) { findTripRecord.incrementViewCount(); }
         incrementViewCount(findTripRecord);
+        tripRecordViewHistoryService.addViewHistory(principalDetails, tripRecordId);
 
         TripRecordDetailResponseDto responseDto = TripRecordDetailResponseDto.fromEntity(findTripRecord);
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -1,18 +1,14 @@
 package com.haejwo.tripcometrue.domain.triprecord.service;
 
-import com.haejwo.tripcometrue.domain.member.exception.UserInvalidAccessException;
-import com.haejwo.tripcometrue.domain.triprecord.dto.request.TripRecordRequestDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.ModelAttribute.TripRecordListRequestAttribute;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewCount;
 import com.haejwo.tripcometrue.domain.triprecord.exception.TripRecordNotFoundException;
-import com.haejwo.tripcometrue.domain.triprecord.repository.TripRecordRepository;
-import com.haejwo.tripcometrue.domain.triprecord.repository.TripRecordViewCountRepository;
-import com.haejwo.tripcometrue.domain.triprecordViewHistory.service.TripRecordViewHistoryService;
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord.TripRecordRepository;
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_viewcount.TripRecordViewCountRepository;
+import com.haejwo.tripcometrue.domain.triprecordViewHistory.service.TripRecordViewHistoryService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/controller/TripRecordViewHistoryController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/controller/TripRecordViewHistoryController.java
@@ -1,0 +1,36 @@
+package com.haejwo.tripcometrue.domain.triprecordViewHistory.controller;
+import com.haejwo.tripcometrue.domain.triprecordViewHistory.dto.response.TripRecordViewHistoryResponseDto;
+import com.haejwo.tripcometrue.domain.triprecordViewHistory.service.TripRecordViewHistoryService;
+import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("v1/trip-record")
+@RequiredArgsConstructor
+public class TripRecordViewHistoryController {
+
+  private final TripRecordViewHistoryService tripRecordViewHistoryService;
+
+  @GetMapping("/view-history")
+  public ResponseEntity<ResponseDTO<Page<TripRecordViewHistoryResponseDto>>> getViewHistory(
+      @AuthenticationPrincipal PrincipalDetails principalDetails,
+      @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+    Page<TripRecordViewHistoryResponseDto> historyPage = tripRecordViewHistoryService.getViewHistory(principalDetails, pageable);
+    ResponseDTO<Page<TripRecordViewHistoryResponseDto>> responseBody = ResponseDTO.okWithData(historyPage);
+
+    return ResponseEntity
+        .status(responseBody.getCode())
+        .body(responseBody);
+    }
+  }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/controller/TripRecordViewHistoryControllerAdvice.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/controller/TripRecordViewHistoryControllerAdvice.java
@@ -1,0 +1,21 @@
+package com.haejwo.tripcometrue.domain.triprecordViewHistory.controller;
+import com.haejwo.tripcometrue.domain.triprecord.exception.TripRecordNotFoundException;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class TripRecordViewHistoryControllerAdvice {
+
+  @ExceptionHandler(TripRecordNotFoundException.class)
+  public ResponseEntity<ResponseDTO<Void>> tripRecordNotFoundExceptionHandler(TripRecordNotFoundException e) {
+    HttpStatus status = e.getErrorCode().getHttpStatus();
+
+    return ResponseEntity
+        .status(status)
+        .body(ResponseDTO.errorWithMessage(status, e.getMessage()));
+  }
+
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/dto/request/TripRecordViewHistoryRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/dto/request/TripRecordViewHistoryRequestDto.java
@@ -1,0 +1,16 @@
+package com.haejwo.tripcometrue.domain.triprecordViewHistory.dto.request;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewHistory;
+
+public record TripRecordViewHistoryRequestDto(
+    Long memberId,
+    Long tripRecordId
+) {
+  public TripRecordViewHistory toEntity(Member member, TripRecord tripRecord) {
+    return TripRecordViewHistory.builder()
+        .member(member)
+        .tripRecord(tripRecord)
+        .build();
+  }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/dto/response/TripRecordViewHistoryResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/dto/response/TripRecordViewHistoryResponseDto.java
@@ -1,0 +1,20 @@
+package com.haejwo.tripcometrue.domain.triprecordViewHistory.dto.response;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewHistory;
+import java.time.LocalDateTime;
+
+public record TripRecordViewHistoryResponseDto(
+    Long id,
+    Long memberId,
+    Long tripRecordId,
+    LocalDateTime createdAt
+) {
+  public static TripRecordViewHistoryResponseDto fromEntity(
+      TripRecordViewHistory tripRecordViewHistory) {
+    return new TripRecordViewHistoryResponseDto(
+        tripRecordViewHistory.getId(),
+        tripRecordViewHistory.getMember().getId(),
+        tripRecordViewHistory.getTripRecord().getId(),
+        tripRecordViewHistory.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/repository/TripRecordViewHistoryRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/repository/TripRecordViewHistoryRepository.java
@@ -1,0 +1,17 @@
+package com.haejwo.tripcometrue.domain.triprecordViewHistory.repository;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewHistory;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TripRecordViewHistoryRepository extends JpaRepository<TripRecordViewHistory, Long> {
+
+  Page<TripRecordViewHistory> findByMember(Member member, Pageable pageable);
+
+  Optional<TripRecordViewHistory> findByMemberIdAndTripRecordId(Long memberId, Long tripRecordId);
+}
+

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/service/TripRecordViewHistoryService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/service/TripRecordViewHistoryService.java
@@ -1,0 +1,57 @@
+package com.haejwo.tripcometrue.domain.triprecordViewHistory.service;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewHistory;
+import com.haejwo.tripcometrue.domain.triprecord.exception.TripRecordNotFoundException;
+import com.haejwo.tripcometrue.domain.triprecord.repository.TripRecordRepository;
+import com.haejwo.tripcometrue.domain.triprecordViewHistory.dto.response.TripRecordViewHistoryResponseDto;
+import com.haejwo.tripcometrue.domain.triprecordViewHistory.repository.TripRecordViewHistoryRepository;
+import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TripRecordViewHistoryService {
+
+  private final TripRecordRepository tripRecordRepository;
+  private final TripRecordViewHistoryRepository tripRecordViewHistoryRepository;
+
+  @Transactional
+  public void addViewHistory(PrincipalDetails principalDetails, Long tripRecordId) {
+    TripRecord tripRecord = tripRecordRepository.findById(tripRecordId)
+        .orElseThrow(TripRecordNotFoundException::new);
+
+    Member member = principalDetails.getMember();
+    Long memberId = member.getId();
+
+    Optional<TripRecordViewHistory> existingHistory = tripRecordViewHistoryRepository
+        .findByMemberIdAndTripRecordId(memberId, tripRecordId);
+
+    TripRecordViewHistory history;
+    if (existingHistory.isPresent()) {  //한번 봤던 기록인 경우
+      history = existingHistory.get();
+      history.updateUpdatedAt();
+    } else {                            //처음 보는 기록인 경우
+      history = TripRecordViewHistory.builder()
+          .member(member)
+          .tripRecord(tripRecord)
+          .build();
+    }
+
+    tripRecordViewHistoryRepository.save(history);
+  }
+
+  @Transactional
+  public Page<TripRecordViewHistoryResponseDto> getViewHistory(PrincipalDetails principalDetails, Pageable pageable) {
+
+    return tripRecordViewHistoryRepository.findByMember(principalDetails.getMember(), pageable)
+        .map(TripRecordViewHistoryResponseDto::fromEntity);
+  }
+
+
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/service/TripRecordViewHistoryService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecordViewHistory/service/TripRecordViewHistoryService.java
@@ -1,9 +1,10 @@
 package com.haejwo.tripcometrue.domain.triprecordViewHistory.service;
+
 import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewHistory;
 import com.haejwo.tripcometrue.domain.triprecord.exception.TripRecordNotFoundException;
-import com.haejwo.tripcometrue.domain.triprecord.repository.TripRecordRepository;
+import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord.TripRecordRepository;
 import com.haejwo.tripcometrue.domain.triprecordViewHistory.dto.response.TripRecordViewHistoryResponseDto;
 import com.haejwo.tripcometrue.domain.triprecordViewHistory.repository.TripRecordViewHistoryRepository;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;

--- a/src/test/http/trip_record/view_history.http
+++ b/src/test/http/trip_record/view_history.http
@@ -1,0 +1,4 @@
+#최근에 본 후기 조회
+GET http://localhost:8080/v1/trip-record/view-history
+Content-Type: application/json
+Authorization: 토큰 값 입력


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)
- [ ] 리팩토링 (Refactoring)
- [ ] 버그 수정 (Bug Fix)
- [ ] 테스트 (Test)
- [ ] CI/CD
- [ ] 설정 (Setup)

- **간략한 설명**:
  : 마이페이지 내부 최근에 본 후기 기능 구현

---

## 🛠 작성/변경 사항

- **(주요작성/변경사항)**
- TripRecordViewHistory 도메인 작성
- TripRecord 조회 마다 trip_record_view_history 테이블에 member_id, trip_record_id 등록 메서드(addViewHistory) 구현
- 기존에 보았던 데이터 처리 -> basetimeEntity의 UpdatedAt 필드값만 수정 후 재저장
- 등록된 데이터 조회 요청 시 UpdatedAt 기준 내림차순 페이지 응답데이터로 전송
---

## 🔗 관련 이슈

- **이슈 링크1** : #38 

---

## 💡 특이 사항

- **주목할 사항** 
  - TripRecordViewHistory 엔티티의 소속 패키지가 일단 triprecord 패키지에 있음
  - TripRecordService 수정은 addViewHistory 추가 및 관련 의존성 주입 외에 없음
  - 추후 예외처리 추가 필요
