### PR TITLE
[feat] 도시 상세 피드 API 1차 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.projectlombok:lombok'
 
 	// yml
 	implementation 'org.yaml:snakeyaml:+'
@@ -68,6 +70,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
+	// httpclient5
+	implementation 'org.apache.httpcomponents.client5:httpclient5:5.3'
 }
 
 jar {

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityController.java
@@ -1,13 +1,18 @@
 package com.haejwo.tripcometrue.domain.city.controller;
 
 import com.haejwo.tripcometrue.domain.city.dto.request.AddCityRequestDto;
+import com.haejwo.tripcometrue.domain.city.dto.response.CityInfoResponseDto;
 import com.haejwo.tripcometrue.domain.city.dto.response.CityResponseDto;
+import com.haejwo.tripcometrue.domain.city.dto.response.ExchangeRateResponseDto;
+import com.haejwo.tripcometrue.domain.city.dto.response.WeatherResponseDto;
 import com.haejwo.tripcometrue.domain.city.service.CityService;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/v1/cities")
@@ -28,24 +33,59 @@ public class CityController {
             );
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ResponseDTO<CityResponseDto>> findCity(
-        @PathVariable("id") Long id
+    @GetMapping("/{cityId}")
+    public ResponseEntity<ResponseDTO<CityInfoResponseDto>> getCityInfo(
+        @PathVariable("cityId") Long cityId
     ) {
 
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(
-                ResponseDTO.okWithData(cityService.findCity(id))
+                ResponseDTO.okWithData(cityService.getCityInfo(cityId))
             );
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<ResponseDTO<Void>> deleteCity(
-        @PathVariable("id") Long id
+    @GetMapping("/exchange-rates")
+    public ResponseEntity<ResponseDTO<ExchangeRateResponseDto>> getExchangeRate(
+        @RequestParam(name = "curUnit") String curUnit
     ) {
 
-        cityService.deleteCity(id);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(
+                ResponseDTO.okWithData(cityService.getExchangeRate(curUnit))
+            );
+    }
+
+    @GetMapping("/{cityId}/weathers")
+    public ResponseEntity<ResponseDTO<List<WeatherResponseDto>>> getWeatherInfo(
+        @PathVariable("cityId") Long cityId
+    ) {
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(
+                ResponseDTO.okWithData(cityService.getWeatherInfo(cityId))
+            );
+    }
+
+    @GetMapping("/v1/cities/{cityId}/hot-places")
+    public ResponseEntity<ResponseDTO<?>> getHotPlaces(
+        @PathVariable("cityId") Long cityId
+    ) {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(
+                ResponseDTO.okWithData(cityService.getHotPlaces(cityId))
+            );
+    }
+
+    @DeleteMapping("/{cityId}")
+    public ResponseEntity<ResponseDTO<Void>> deleteCity(
+        @PathVariable("cityId") Long cityId
+    ) {
+
+        cityService.deleteCity(cityId);
 
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/ExchangeRateApiDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/ExchangeRateApiDto.java
@@ -1,0 +1,15 @@
+package com.haejwo.tripcometrue.domain.city.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ExchangeRateApiDto(
+    @JsonProperty("result")
+    Integer result,
+    @JsonProperty("cur_unit")
+    String curUnit,
+    @JsonProperty("cur_nm")
+    String curName,
+    @JsonProperty("deal_bas_r")
+    String dealBaseRate
+) {
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/request/AddCityRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/request/AddCityRequestDto.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.city.dto.request;
 
 import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
 import com.haejwo.tripcometrue.global.enums.Country;
 
 public record AddCityRequestDto(
@@ -21,7 +22,7 @@ public record AddCityRequestDto(
             .timeDifference(this.timeDifference)
             .voltage(this.voltage)
             .visa(this.visa)
-            .currency(this.currency)
+            .currency(CurrencyUnit.valueOf(this.currency))
             .weatherRecommendation(this.weatherRecommendation)
             .weatherDescription(this.weatherDescription)
             .country(this.country)

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityInfoResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityInfoResponseDto.java
@@ -1,0 +1,33 @@
+package com.haejwo.tripcometrue.domain.city.dto.response;
+
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import lombok.Builder;
+
+public record CityInfoResponseDto(
+    Long id,
+    String name,
+    String language,
+    String timeDifference,
+    String voltage,
+    String visa,
+    String curUnit,
+    String curName
+) {
+
+    @Builder
+    public CityInfoResponseDto {
+    }
+
+    public static CityInfoResponseDto fromEntity(City entity) {
+        return CityInfoResponseDto.builder()
+            .id(entity.getId())
+            .name(entity.getName())
+            .language(entity.getLanguage())
+            .timeDifference(entity.getTimeDifference())
+            .voltage(entity.getVoltage())
+            .visa(entity.getVisa())
+            .curUnit(entity.getCurrency().toString())
+            .curName(entity.getCurrency().getCurrencyName())
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
@@ -1,7 +1,10 @@
 package com.haejwo.tripcometrue.domain.city.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.haejwo.tripcometrue.domain.city.entity.City;
+import lombok.Builder;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record CityResponseDto(
     Long id,
     String name,
@@ -14,18 +17,23 @@ public record CityResponseDto(
     String weatherDescription,
     String country
 ) {
+
+    @Builder
+    public CityResponseDto {
+    }
+
     public static CityResponseDto fromEntity(City entity) {
-        return new CityResponseDto(
-            entity.getId(),
-            entity.getName(),
-            entity.getLanguage(),
-            entity.getTimeDifference(),
-            entity.getVoltage(),
-            entity.getVisa(),
-            entity.getCurrency(),
-            entity.getWeatherRecommendation(),
-            entity.getWeatherDescription(),
-            entity.getCountry().getDescription()
-        );
+        return CityResponseDto.builder()
+            .id(entity.getId())
+            .name(entity.getName())
+            .language(entity.getLanguage())
+            .timeDifference(entity.getTimeDifference())
+            .voltage(entity.getVoltage())
+            .visa(entity.getVisa())
+            .currency(entity.getCurrency().name())
+            .weatherRecommendation(entity.getWeatherRecommendation())
+            .weatherDescription(entity.getWeatherDescription())
+            .country(entity.getCountry().getDescription())
+            .build();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/ExchangeRateResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/ExchangeRateResponseDto.java
@@ -1,0 +1,14 @@
+package com.haejwo.tripcometrue.domain.city.dto.response;
+
+import lombok.Builder;
+
+public record ExchangeRateResponseDto(
+    String curUnit,
+    String curName,
+    String exchangeRate
+) {
+
+    @Builder
+    public ExchangeRateResponseDto {
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/HotPlaceResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/HotPlaceResponseDto.java
@@ -1,0 +1,28 @@
+package com.haejwo.tripcometrue.domain.city.dto.response;
+
+import com.haejwo.tripcometrue.domain.place.entity.Place;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordScheduleImage;
+import lombok.Builder;
+
+import java.util.Objects;
+
+public record HotPlaceResponseDto(
+    Long placeId,
+    String placeName,
+    Integer storedCount,
+    String imageUrl
+) {
+
+    @Builder
+    public HotPlaceResponseDto {
+    }
+
+    public static HotPlaceResponseDto fromEntity(Place entity, TripRecordScheduleImage image) {
+        return HotPlaceResponseDto.builder()
+            .placeId(entity.getId())
+            .placeName(entity.getName())
+            .storedCount(entity.getStoredCount())
+            .imageUrl(Objects.isNull(image) ? null : image.getImageUrl())
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/WeatherResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/WeatherResponseDto.java
@@ -1,0 +1,27 @@
+package com.haejwo.tripcometrue.domain.city.dto.response;
+
+import com.haejwo.tripcometrue.domain.city.entity.Weather;
+import lombok.Builder;
+
+public record WeatherResponseDto(
+    Integer month,
+    String maxAvgTempC,
+    String minAvgTempC,
+    String maxAvgTempF,
+    String minAvgTempF
+) {
+
+    @Builder
+    public WeatherResponseDto {
+    }
+
+    public static WeatherResponseDto fromEntity(Weather entity, String maxAvgTempF, String minAvgTempF) {
+        return WeatherResponseDto.builder()
+            .month(entity.getMonth())
+            .maxAvgTempC(entity.getMaxAvgTemp())
+            .minAvgTempC(entity.getMinAvgTemp())
+            .maxAvgTempF(maxAvgTempF)
+            .minAvgTempF(minAvgTempF)
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
@@ -22,7 +22,7 @@ public class City extends BaseTimeEntity {
     private String timeDifference;
     private String voltage;
     private String visa;
-    private String currency;
+    private CurrencyUnit currency;
     private String weatherRecommendation;
     private String weatherDescription;
 
@@ -32,7 +32,7 @@ public class City extends BaseTimeEntity {
     @Builder
     private City(
         Long id, String name, String language, String timeDifference,
-        String voltage, String visa, String currency, String weatherRecommendation,
+        String voltage, String visa, CurrencyUnit currency, String weatherRecommendation,
         String weatherDescription, Country country
     ) {
         this.id = id;

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/entity/CurrencyUnit.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/entity/CurrencyUnit.java
@@ -1,0 +1,36 @@
+package com.haejwo.tripcometrue.domain.city.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum CurrencyUnit {
+
+    AED("아랍에미리트 디르함", 1),
+    AUD("호주 달러", 1),
+    BHD("바레인 디나르", 1),
+    BND("브루나이 달러", 1),
+    CAD("캐나다 달러", 1),
+    CHF("스위스 프랑", 1),
+    CNH("위안화", 1),
+    DKK("덴마아크 크로네", 1),
+    EUR("유로", 1),
+    GBP("영국 파운드", 1),
+    HKD("홍콩 달러", 1),
+    IDR("인도네시아 루피아", 100),
+    JPY("일본 엔", 100),
+    KWD("쿠웨이트 디나르", 1),
+    MYR("말레이시아 링기트", 1),
+    NLG("네덜란드 길더", 1),
+    NOK("노르웨이 크로네", 1),
+    NZD("뉴질랜드 달러", 1),
+    SAR("사우디 리얄", 1),
+    SEK("스웨덴 크로나", 1),
+    SGD("싱가포르 달러", 1),
+    THB("태국 바트", 1),
+    USD("미국 달러", 1);
+
+    private final String currencyName;
+    private final Integer standard;
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/entity/Weather.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/entity/Weather.java
@@ -1,0 +1,38 @@
+package com.haejwo.tripcometrue.domain.city.entity;
+
+import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Weather extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer month;
+
+    private String maxAvgTemp;
+
+    private String minAvgTemp;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "city_id")
+    private City city;
+
+    @Builder
+    private Weather(Long id, City city, Integer month,
+                    String maxAvgTemp, String minAvgTemp) {
+        this.id = id;
+        this.city = city;
+        this.month = month;
+        this.maxAvgTemp = maxAvgTemp;
+        this.minAvgTemp = minAvgTemp;
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/exception/ExchangeRateApiCallFailException.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/exception/ExchangeRateApiCallFailException.java
@@ -1,0 +1,16 @@
+package com.haejwo.tripcometrue.domain.city.exception;
+
+import com.haejwo.tripcometrue.global.exception.ApplicationException;
+import com.haejwo.tripcometrue.global.exception.ErrorCode;
+
+public class ExchangeRateApiCallFailException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.EXCHANGE_RATE_API_FAIL;
+    public ExchangeRateApiCallFailException() {
+        super(ERROR_CODE);
+    }
+
+    public ExchangeRateApiCallFailException(String message) {
+        super(ERROR_CODE, message);
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/repository/WeatherRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/repository/WeatherRepository.java
@@ -1,0 +1,12 @@
+package com.haejwo.tripcometrue.domain.city.repository;
+
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.entity.Weather;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WeatherRepository extends JpaRepository<Weather, Long> {
+
+    List<Weather> findAllByCityAndMonthInOrderByMonthAsc(City city, List<Integer> months);
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityService.java
@@ -1,19 +1,37 @@
 package com.haejwo.tripcometrue.domain.city.service;
 
 import com.haejwo.tripcometrue.domain.city.dto.request.AddCityRequestDto;
-import com.haejwo.tripcometrue.domain.city.dto.response.CityResponseDto;
+import com.haejwo.tripcometrue.domain.city.dto.response.*;
 import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.domain.city.entity.Weather;
 import com.haejwo.tripcometrue.domain.city.exception.CityNotFoundException;
 import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
+import com.haejwo.tripcometrue.domain.city.repository.WeatherRepository;
+import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class CityService {
 
     private final CityRepository cityRepository;
+    private final PlaceRepository placeRepository;
+    private final WeatherRepository weatherRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final int WEATHER_MONTH_GAP = 3;
+    private static final int CITY_HOT_PLACES_SIZE = 10;
 
     @Transactional
     public CityResponseDto addCity(AddCityRequestDto request) {
@@ -23,18 +41,104 @@ public class CityService {
     }
 
     @Transactional(readOnly = true)
-    public CityResponseDto findCity(Long id) {
-        return CityResponseDto.fromEntity(
-            cityRepository.findById(id)
-                .orElseThrow(CityNotFoundException::new)
+    public List<HotPlaceResponseDto> getHotPlaces(Long id) {
+        City city = getCityEntity(id);
+
+        return placeRepository
+            .findPlacesByCityAndOrderByStoredCountLimitSize(city, CITY_HOT_PLACES_SIZE)
+            .stream()
+            .map(place -> {
+                // TODO : 핫플 대표 이미지 조회해서 응답 보내기
+                return HotPlaceResponseDto.fromEntity(place, null);
+            }).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CityInfoResponseDto getCityInfo(Long id) {
+        return CityInfoResponseDto.fromEntity(
+            getCityEntity(id)
         );
+    }
+
+    @Transactional(readOnly = true)
+    public ExchangeRateResponseDto getExchangeRate(String curUnit) {
+        CurrencyUnit currencyUnit = validateAndConvertToCurrencyUnit(curUnit);
+
+        String exchangeRate = (String) redisTemplate.opsForValue()
+            .get("exchange-rate:" + currencyUnit);
+
+        return ExchangeRateResponseDto.builder()
+            .curUnit(currencyUnit.name())
+            .curName(currencyUnit.getCurrencyName())
+            .exchangeRate(exchangeRate)
+            .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<WeatherResponseDto> getWeatherInfo(Long id) {
+        City city = getCityEntity(id);
+
+        // 현재 달 포함 향후 3개월
+        int curMonth = LocalDate.now().getMonthValue();
+        List<Integer> months = new ArrayList<>();
+        for (int i = 0; i <= WEATHER_MONTH_GAP; i++) {
+            months.add(((curMonth + i) % 13) + 1);
+        }
+
+        List<Weather> weathers = weatherRepository.findAllByCityAndMonthInOrderByMonthAsc(city, months);
+
+        return sortWeatherInfos(weathers)
+            .stream()
+            .map(
+                w -> WeatherResponseDto.fromEntity(w, convertToTempF(w.getMaxAvgTemp()), convertToTempF(w.getMinAvgTemp()))
+            ).toList();
     }
 
     @Transactional
     public void deleteCity(Long id) {
-        City city = cityRepository.findById(id)
-            .orElseThrow(CityNotFoundException::new);
+        City city = getCityEntity(id);
 
         cityRepository.delete(city);
+    }
+
+    private City getCityEntity(Long id) {
+        return cityRepository.findById(id)
+            .orElseThrow(CityNotFoundException::new);
+    }
+
+    private List<Weather> sortWeatherInfos(List<Weather> weathers) {
+        int lastIdx = weathers.size() - 1;
+
+        if(weathers.get(lastIdx).getMonth() - weathers.get(0).getMonth() > WEATHER_MONTH_GAP) {
+            weathers.add(0, weathers.remove(lastIdx));
+
+            for (int i = lastIdx; i >= 0; i--) {
+                int last = weathers.get(lastIdx).getMonth();
+                int prev = weathers.get(lastIdx - 1).getMonth();
+
+                weathers.add(0, weathers.remove(lastIdx));
+
+                if (last - prev != 1) {
+                    break;
+                }
+            }
+        }
+
+        return weathers;
+    }
+
+    private String convertToTempF(String tempC) {
+        return new BigDecimal(tempC)
+            .multiply(new BigDecimal("1.8"))
+            .add(new BigDecimal("32"))
+            .setScale(2, RoundingMode.HALF_UP)
+            .toString();
+    }
+
+    private CurrencyUnit validateAndConvertToCurrencyUnit(String curUnit) {
+        return Arrays.stream(CurrencyUnit.values())
+            .filter(currencyUnit -> currencyUnit.name().equals(curUnit.toUpperCase()))
+            .findFirst()
+            .orElseThrow();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/ExchangeRateApiCaller.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/ExchangeRateApiCaller.java
@@ -1,0 +1,71 @@
+package com.haejwo.tripcometrue.domain.city.service;
+
+import com.haejwo.tripcometrue.domain.city.dto.ExchangeRateApiDto;
+import com.haejwo.tripcometrue.domain.city.exception.ExchangeRateApiCallFailException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Service
+public class ExchangeRateApiCaller {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${exchange-rate.api.url}")
+    private String API_URL;
+
+    @Value("${exchange-rate.api.key}")
+    private String API_KEY;
+
+    public List<ExchangeRateApiDto> call() {
+
+        URI uri = buildUri(LocalDate.now());
+
+        try {
+            ResponseEntity<List<ExchangeRateApiDto>> responseEntity = restTemplate.exchange(
+                uri, HttpMethod.GET, null, new ParameterizedTypeReference<>() {}
+            );
+
+            if(Objects.nonNull(responseEntity.getBody()) && responseEntity.getBody().get(0).result() != 1) {
+                Integer result = responseEntity.getBody().get(0).result();
+                String errorMessage = switch (result) {
+                    case 2 -> "DATA 코드 오류";
+                    case 3 -> "인증코드 오류";
+                    case 4 -> "일일제한횟수 마감";
+                    default -> "환율 API 호출 실패";
+                };
+
+                throw new ExchangeRateApiCallFailException(errorMessage);
+            }
+
+            return responseEntity.getBody();
+        } catch (Exception e) {
+            throw new ExchangeRateApiCallFailException();
+        }
+    }
+
+    private URI buildUri(LocalDate date) {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        return UriComponentsBuilder
+            .fromHttpUrl(API_URL)
+            .queryParam("authkey", API_KEY)
+            .queryParam("searchdate", dateFormatter.format(date))
+            .queryParam("data", "AP01")
+            .build()
+            .encode()
+            .toUri();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/ExchangeRateUpdateScheduler.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/ExchangeRateUpdateScheduler.java
@@ -1,0 +1,52 @@
+package com.haejwo.tripcometrue.domain.city.service;
+
+import com.haejwo.tripcometrue.domain.city.dto.ExchangeRateApiDto;
+import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ExchangeRateUpdateScheduler {
+
+    private final ExchangeRateApiCaller exchangeRateApiCaller;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String EXCHANGE_RATE_REDIS_KEY_PREFIX = "exchange-rate:";
+
+    // 매일 9:00, 12:00, 15:00 환율 정보 업데이트
+    @Scheduled(cron = "0 0 9,12,15 * * *")
+    public void update() {
+        List<ExchangeRateApiDto> exchangeRates = exchangeRateApiCaller.call();
+
+        for (ExchangeRateApiDto exchangeRate : exchangeRates) {
+            String curUnitString = exchangeRate.curUnit().trim().substring(0, 3);
+
+            if(curUnitString.equals("KRW")) continue;
+
+            saveExchangeRateToRedis(exchangeRate, curUnitString);
+        }
+    }
+
+    private void saveExchangeRateToRedis(ExchangeRateApiDto exchangeRate, String curUnitString) {
+        ValueOperations<String, Object> operations = redisTemplate.opsForValue();
+        CurrencyUnit currencyUnit = CurrencyUnit.valueOf(curUnitString);
+
+        String key = EXCHANGE_RATE_REDIS_KEY_PREFIX + currencyUnit;
+        String value = currencyUnit.getStandard() + ":" + exchangeRate.dealBaseRate();
+
+        if (currencyUnit.getStandard() != 1) {
+            BigDecimal rate = new BigDecimal(exchangeRate.dealBaseRate())
+                .divide(new BigDecimal(currencyUnit.getStandard()));
+
+            value = "1:" + rate;
+        }
+
+        operations.set(key, value);
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/dto/request/PlaceRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/dto/request/PlaceRequestDto.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.place.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.haejwo.tripcometrue.domain.city.entity.City;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import java.time.LocalTime;
 import lombok.Builder;
@@ -40,7 +41,7 @@ public record PlaceRequestDto(
         this.cityId = cityId;
     }
 
-    public Place toEntity() {
+    public Place toEntity(City city) {
         return Place.builder()
             .name(this.name)
             .address(this.address)
@@ -50,7 +51,7 @@ public record PlaceRequestDto(
             .weekendOpenTime(this.weekendOpenTime)
             .weekendCloseTime(this.weekendCloseTime)
             .storedCount(this.storedCount)
-            .cityId(this.cityId)
+            .city(city)
             .build();
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/dto/response/PlaceResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/dto/response/PlaceResponseDto.java
@@ -53,7 +53,7 @@ public record PlaceResponseDto(
             .weekendOpenTime(entity.getWeekendOpenTime())
             .weekendCloseTime(entity.getWeekendCloseTime())
             .storedCount(entity.getStoredCount())
-            .cityId(entity.getCityId())
+            .cityId(entity.getCity().getId())
             .build();
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/entity/Place.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/entity/Place.java
@@ -1,13 +1,10 @@
 package com.haejwo.tripcometrue.domain.place.entity;
 
+import com.haejwo.tripcometrue.domain.city.entity.City;
 import com.haejwo.tripcometrue.domain.place.dto.request.PlaceRequestDto;
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
+import jakarta.persistence.*;
+
 import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -37,8 +34,9 @@ public class Place extends BaseTimeEntity {
     private Double latitude;
     private Double longitude;
 
-    // 임시 City 테이블 데이터
-    private Long cityId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "city_id")
+    private City city;
 
     @PrePersist
     public void prePersist() {
@@ -50,7 +48,7 @@ public class Place extends BaseTimeEntity {
         Long id, String name, String address, String description,
         LocalTime weekdayOpenTime, LocalTime weekdayCloseTime,
         LocalTime weekendOpenTime, LocalTime weekendCloseTime,
-        Integer storedCount, Long cityId, Double latitude, Double longitude) {
+        Integer storedCount, City city, Double latitude, Double longitude) {
         this.id = id;
         this.name = name;
         this.address = address;
@@ -60,7 +58,7 @@ public class Place extends BaseTimeEntity {
         this.weekendOpenTime = weekendOpenTime;
         this.weekendCloseTime = weekendCloseTime;
         this.storedCount = storedCount;
-        this.cityId = cityId;
+        this.city = city;
         this.latitude = latitude;
         this.longitude = longitude;
     }
@@ -74,6 +72,5 @@ public class Place extends BaseTimeEntity {
         this.weekendOpenTime = requestDto.weekendOpenTime();
         this.weekendCloseTime = requestDto.weekendCloseTime();
         this.storedCount = requestDto.storedCount();
-        this.cityId = requestDto.cityId();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepository.java
@@ -1,12 +1,16 @@
 package com.haejwo.tripcometrue.domain.place.repositroy;
 
+import com.haejwo.tripcometrue.domain.city.entity.City;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface PlaceCustomRepository {
 
     Page<Place> findPlaceWithFilter(Pageable pageable,
                                     Integer storedCount);
 
+    List<Place> findPlacesByCityAndOrderByStoredCountLimitSize(City city, int size);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepositoryImpl.java
@@ -1,9 +1,12 @@
 package com.haejwo.tripcometrue.domain.place.repositroy;
 
+import com.haejwo.tripcometrue.domain.city.entity.City;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.place.entity.QPlace;
 import com.querydsl.core.BooleanBuilder;
 import java.util.List;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -11,8 +14,11 @@ import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 
 public class PlaceCustomRepositoryImpl extends QuerydslRepositorySupport implements PlaceCustomRepository {
 
-    public PlaceCustomRepositoryImpl() {
+    private final JPAQueryFactory queryFactory;
+
+    public PlaceCustomRepositoryImpl(JPAQueryFactory queryFactory) {
         super(Place.class);
+        this.queryFactory = queryFactory;
     }
 
     @Override
@@ -36,5 +42,19 @@ public class PlaceCustomRepositoryImpl extends QuerydslRepositorySupport impleme
 
         return new PageImpl<>(result, pageable, total);
 
+    }
+
+    @Override
+    public List<Place> findPlacesByCityAndOrderByStoredCountLimitSize(City city, int size) {
+
+        QPlace place = QPlace.place;
+
+        return queryFactory
+            .selectFrom(place)
+            .join(place.city)
+            .where(place.city.eq(city))
+            .orderBy(place.storedCount.desc(), place.createdAt.desc())
+            .limit(size)
+            .fetch();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/service/PlaceService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/service/PlaceService.java
@@ -1,5 +1,8 @@
 package com.haejwo.tripcometrue.domain.place.service;
 
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.exception.CityNotFoundException;
+import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
 import com.haejwo.tripcometrue.domain.place.dto.request.PlaceRequestDto;
 import com.haejwo.tripcometrue.domain.place.dto.response.PlaceResponseDto;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
@@ -18,11 +21,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlaceService {
 
     private final PlaceRepository placeRepository;
+    private final CityRepository cityRepository;
 
     @Transactional
     public PlaceResponseDto addPlace(PlaceRequestDto requestDto) {
-
-        Place requestPlace = requestDto.toEntity();
+        City city = cityRepository.findById(requestDto.cityId())
+            .orElseThrow(CityNotFoundException::new);
+        Place requestPlace = requestDto.toEntity(city);
         Place savedPlace = placeRepository.save(requestPlace);
         PlaceResponseDto responseDto = PlaceResponseDto.fromEntity(savedPlace);
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/request/TripRecordScheduleRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/request/TripRecordScheduleRequestDto.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.triprecord.dto.request;
 
 import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordSchedule;
 import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExternalLinkTagType;
@@ -22,12 +23,12 @@ public record TripRecordScheduleRequestDto(
     String tagUrl
 ) {
 
-    public TripRecordSchedule toEntity(TripRecord tripRecord, Member member) {
+    public TripRecordSchedule toEntity(TripRecord tripRecord, Member member, Place place) {
         return TripRecordSchedule.builder()
             .dayNumber(this.dayNumber)
             .ordering(this.orderNumber)
             .content(this.content)
-            .placeId(this.placeId)
+            .place(place)
             .tripRecord(tripRecord)
             .tagType(this.tagType)
             .tagUrl(this.tagUrl)

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/trip_record_schedule_video/TripRecordScheduleVideoResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/trip_record_schedule_video/TripRecordScheduleVideoResponseDto.java
@@ -1,0 +1,9 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.response.trip_record_schedule_video;
+
+public record TripRecordScheduleVideoResponseDto(
+    Long tripRecordId,
+    String tripRecordTitle,
+    Integer storedCount,
+    String thumbnail
+) {
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule/TripRecordScheduleDetailResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule/TripRecordScheduleDetailResponseDto.java
@@ -51,7 +51,7 @@ public record TripRecordScheduleDetailResponseDto(
             .dayNumber(entity.getDayNumber())
             .ordering(entity.getOrdering())
             .content(entity.getContent())
-            .placeId(entity.getPlaceId())
+            .placeId(entity.getPlace().getId())
             .tripRecordId(entity.getTripRecord() != null ? entity.getTripRecord().getId() : null)
             .images(imageDtos)
             .videos(videoDtos)

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordSchedule.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordSchedule.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.triprecord.entity;
 
 import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExternalLinkTagType;
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
@@ -40,20 +41,23 @@ public class TripRecordSchedule extends BaseTimeEntity {
 
     private String content;
 
-    private Long placeId;
-
-    @ManyToOne
-    @JoinColumn(name = "tripRecord_id")
-    private TripRecord tripRecord;
-
     @OneToMany(mappedBy = "tripRecordSchedule", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<TripRecordScheduleImage> tripRecordScheduleImages = new ArrayList<>();
 
     @OneToMany(mappedBy = "tripRecordSchedule", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<TripRecordScheduleVideo> tripRecordScheduleVideos = new ArrayList<>();
 
+    @ManyToOne
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    @ManyToOne
+    @JoinColumn(name = "trip_record_id")
+    private TripRecord tripRecord;
+
     @Enumerated(EnumType.STRING)
     private ExternalLinkTagType tagType;
+
     private String tagUrl;
 
     @ManyToOne
@@ -62,16 +66,15 @@ public class TripRecordSchedule extends BaseTimeEntity {
 
     @Builder
     public TripRecordSchedule(Integer dayNumber, Integer ordering, String content,
-        Long placeId, TripRecord tripRecord, ExternalLinkTagType tagType, String tagUrl,
+        Place place, TripRecord tripRecord, ExternalLinkTagType tagType, String tagUrl,
         Member member) {
         this.dayNumber = dayNumber;
         this.ordering = ordering;
         this.content = content;
-        this.placeId = placeId;
+        this.place = place;
         this.tripRecord = tripRecord;
         this.tagType = tagType;
         this.tagUrl = tagUrl;
         this.member = member;
-
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/TripRecordCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/TripRecordCustomRepositoryImpl.java
@@ -35,7 +35,7 @@ public class TripRecordCustomRepositoryImpl extends QuerydslRepositorySupport im
         }
         // placeId
         if(request.placeId() != null) {
-            booleanBuilder.and(qTripRecordSchedule.placeId.eq(request.placeId()));
+            booleanBuilder.and(qTripRecordSchedule.place.id.eq(request.placeId()));
         }
 
         // expenseRangeType

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
@@ -2,6 +2,8 @@ package com.haejwo.tripcometrue.domain.triprecord.service;
 
 import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.place.entity.Place;
+import com.haejwo.tripcometrue.domain.place.exception.PlaceNotFoundException;
 import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.CreateSchedulePlaceRequestDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.TripRecordRequestDto;
@@ -70,8 +72,11 @@ public class TripRecordEditService {
     private void saveTripRecordSchedules(TripRecordRequestDto requestDto,
         TripRecord requestTripRecord, Member member) {
         requestDto.tripRecordSchedules().forEach(tripRecordScheduleRequestDto -> {
+            Place place = placeRepository.findById(tripRecordScheduleRequestDto.placeId())
+                .orElseThrow(PlaceNotFoundException::new);
+
             TripRecordSchedule tripRecordSchedule = tripRecordScheduleRequestDto.toEntity(
-                requestTripRecord, member);
+                requestTripRecord, member, place);
             tripRecordScheduleRepository.save(tripRecordSchedule);
 
             saveTripRecordScheduleImages(tripRecordScheduleRequestDto, tripRecordSchedule);

--- a/src/main/java/com/haejwo/tripcometrue/global/config/QuerydslConfig.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.haejwo.tripcometrue.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}
+

--- a/src/main/java/com/haejwo/tripcometrue/global/config/RedisTemplateConfig.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/config/RedisTemplateConfig.java
@@ -1,0 +1,38 @@
+package com.haejwo.tripcometrue.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisTemplateConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/config/RestTemplateConfig.java
@@ -1,0 +1,38 @@
+package com.haejwo.tripcometrue.global.config;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    CloseableHttpClient httpClient() {
+        return HttpClientBuilder.create()
+            .setConnectionManager(
+                PoolingHttpClientConnectionManagerBuilder.create()
+                    .setMaxConnPerRoute(50)
+                    .setMaxConnTotal(300)
+                    .build()
+            ).build();
+    }
+
+    @Bean
+    HttpComponentsClientHttpRequestFactory factory(CloseableHttpClient httpClient) {
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setHttpClient(httpClient);
+
+        return factory;
+    }
+
+    @Bean
+    RestTemplate restTemplate(HttpComponentsClientHttpRequestFactory factory) {
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/config/SchedulingConfig.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.haejwo.tripcometrue.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulingConfig {
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 
     // CITY
     CITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 도시입니다."),
+    EXCHANGE_RATE_API_FAIL(HttpStatus.BAD_REQUEST, "환율 Open API 호출 실패했습니다."),
 
     // PLACE
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행지입니다."),

--- a/src/main/java/com/haejwo/tripcometrue/global/springsecurity/SpringSecurityConfig.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/springsecurity/SpringSecurityConfig.java
@@ -72,6 +72,7 @@ public class SpringSecurityConfig {
             .requestMatchers(new AntPathRequestMatcher("/v1/member/check-duplicated-email")).permitAll()
             .requestMatchers(new AntPathRequestMatcher("/v1/member/oauth2/info/**")).permitAll()
 
+            .requestMatchers(new AntPathRequestMatcher("/v1/cities/**")).permitAll()
             .requestMatchers(new AntPathRequestMatcher("/v1/places/**")).permitAll()
             .requestMatchers(new AntPathRequestMatcher("/v1/images/**")).permitAll()
             .requestMatchers(new AntPathRequestMatcher("/v1/trip-places/**")).permitAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,11 @@ spring:
       max-file-size: 5MB
       max-request-size: 5MB
 
+  jpa:
+    properties:
+      hibernate:
+        default_batch_fetch_size: 200
+
 cloud:
   aws:
     credentials:
@@ -17,3 +22,8 @@ cloud:
       secretKey: ${AWS_SECRET_KEY}
     region:
       static: ${AWS_S3_REGION}
+
+exchange-rate:
+  api:
+    url: ${EXCHANGE_RATE_API_URL}
+    key: ${EXCHANGE_RATE_API_KEY}

--- a/src/test/java/com/haejwo/tripcometrue/config/AbstractContainersSupport.java
+++ b/src/test/java/com/haejwo/tripcometrue/config/AbstractContainersSupport.java
@@ -1,0 +1,24 @@
+package com.haejwo.tripcometrue.config;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+
+public abstract class AbstractContainersSupport {
+
+    static final String REDIS_IMAGE = "redis:6-alpine";
+    static final GenericContainer REDIS_CONTAINER;
+
+    static {
+        REDIS_CONTAINER = new GenericContainer<>(REDIS_IMAGE)
+            .withExposedPorts(6379)
+            .withReuse(true);
+        REDIS_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    public static void overrideProps(DynamicPropertyRegistry registry){
+        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS_CONTAINER.getMappedPort(6379).toString());
+    }
+}

--- a/src/test/java/com/haejwo/tripcometrue/config/TestQuerydslConfig.java
+++ b/src/test/java/com/haejwo/tripcometrue/config/TestQuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.haejwo.tripcometrue.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/haejwo/tripcometrue/domain/city/repository/WeatherRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/city/repository/WeatherRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.haejwo.tripcometrue.domain.city.repository;
+
+import com.haejwo.tripcometrue.config.TestQuerydslConfig;
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.domain.city.entity.Weather;
+import com.haejwo.tripcometrue.global.enums.Country;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(TestQuerydslConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class WeatherRepositoryTest {
+
+    @Autowired
+    private CityRepository cityRepository;
+
+    @Autowired
+    private WeatherRepository weatherRepository;
+
+    private City city;
+
+    @BeforeEach
+    void setUp() {
+        city = cityRepository.save(
+            City.builder()
+                .name("방콕")
+                .language("태국어")
+                .timeDifference("2시간 느림")
+                .currency(CurrencyUnit.THB)
+                .visa("visa")
+                .weatherRecommendation("11~12월이 여행하기 가장 좋은 시기입니다.")
+                .weatherDescription("방콕 날씨 설명")
+                .voltage("220V")
+                .country(Country.THAILAND)
+                .build()
+        );
+
+        for (int i = 1; i <= 12; i++) {
+            weatherRepository.save(
+                Weather.builder()
+                    .city(city)
+                    .month(i)
+                    .maxAvgTemp("32.2")
+                    .minAvgTemp("30.1")
+                    .build()
+            );
+        }
+    }
+
+    @Test
+    void findAllByCityAndMonthBetweenOrderByMonthAsc() {
+        // given
+        List<Integer> monthList = List.of(10, 11, 12, 1);
+
+        // when
+        List<Weather> result = weatherRepository.findAllByCityAndMonthInOrderByMonthAsc(city, monthList);
+
+        // then
+        assertThat(result).hasSize(4);
+        assertThat(result.get(0).getMonth()).isEqualTo(1);
+        assertThat(result.get(3).getMonth()).isEqualTo(12);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        weatherRepository.deleteAll();
+        cityRepository.deleteAll();
+    }
+}

--- a/src/test/java/com/haejwo/tripcometrue/domain/city/service/CityServiceTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/city/service/CityServiceTest.java
@@ -100,7 +100,6 @@ class CityServiceTest extends AbstractContainersSupport {
     void getWeatherInfo() {
         // given
         long cityId = city.getId();
-        int curMonth = LocalDate.now().getMonthValue();
 
         // when
         List<WeatherResponseDto> weatherInfos = cityService.getWeatherInfo(cityId);

--- a/src/test/java/com/haejwo/tripcometrue/domain/city/service/CityServiceTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/city/service/CityServiceTest.java
@@ -1,0 +1,139 @@
+package com.haejwo.tripcometrue.domain.city.service;
+
+import com.haejwo.tripcometrue.config.AbstractContainersSupport;
+import com.haejwo.tripcometrue.domain.city.dto.response.CityInfoResponseDto;
+import com.haejwo.tripcometrue.domain.city.dto.response.WeatherResponseDto;
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.domain.city.entity.Weather;
+import com.haejwo.tripcometrue.domain.city.exception.CityNotFoundException;
+import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
+import com.haejwo.tripcometrue.domain.city.repository.WeatherRepository;
+import com.haejwo.tripcometrue.domain.place.entity.Place;
+import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
+import com.haejwo.tripcometrue.global.enums.Country;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest
+class CityServiceTest extends AbstractContainersSupport {
+
+    @Autowired
+    private CityService cityService;
+
+    @Autowired
+    private CityRepository cityRepository;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private WeatherRepository weatherRepository;
+
+    private City city;
+
+    @BeforeEach
+    void setUp() {
+        city = cityRepository.save(
+            City.builder()
+                .name("방콕")
+                .language("태국어")
+                .timeDifference("2시간 느림")
+                .currency(CurrencyUnit.THB)
+                .visa("visa")
+                .weatherRecommendation("11~12월이 여행하기 가장 좋은 시기입니다.")
+                .weatherDescription("방콕 날씨 설명")
+                .voltage("220V")
+                .country(Country.THAILAND)
+                .build()
+        );
+
+        for (int i = 1; i <= 15; i++) {
+            placeRepository.save(
+                Place.builder()
+                    .city(city)
+                    .address("여행지" + i + " 주소")
+                    .name("방콕 여행지" + i)
+                    .description("여행지 설명")
+                    .storedCount(100 + i)
+                    .build()
+            );
+        }
+
+        for (int i = 1; i <= 12; i++) {
+            weatherRepository.save(
+                Weather.builder()
+                    .city(city)
+                    .month(i)
+                    .maxAvgTemp("32.2")
+                    .minAvgTemp("30.1")
+                    .build()
+            );
+        }
+    }
+
+    @Test
+    void getCityInfo() {
+        // given
+        long cityId = city.getId();
+
+        // when
+        CityInfoResponseDto cityInfo = cityService.getCityInfo(cityId);
+
+        // then
+        assertThat(cityInfo.name()).isEqualTo("방콕");
+        assertThat(cityInfo.language()).isEqualTo("태국어");
+        assertThat(cityInfo.curUnit()).isEqualTo(CurrencyUnit.THB.name());
+    }
+
+    @Test
+    void getWeatherInfo() {
+        // given
+        long cityId = city.getId();
+        int curMonth = LocalDate.now().getMonthValue();
+
+        // when
+        List<WeatherResponseDto> weatherInfos = cityService.getWeatherInfo(cityId);
+
+        // then
+        assertThat(weatherInfos).hasSize(4);
+    }
+
+    @Test
+    void getCityInfo_cityNotFoundException() {
+        // given
+        long cityId = 10000;
+
+        // when & then
+        assertThatThrownBy(() -> cityService.getCityInfo(cityId))
+            .isInstanceOf(CityNotFoundException.class);
+    }
+
+    @Test
+    void getWeatherInfo_cityNotFoundException() {
+        // given
+        long cityId = 10000;
+
+        // when & then
+        assertThatThrownBy(() -> cityService.getWeatherInfo(cityId))
+            .isInstanceOf(CityNotFoundException.class);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        log.info("cleanUp 실행");
+        weatherRepository.deleteAll();
+        placeRepository.deleteAll();
+        cityRepository.deleteAll();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   config:
     import: optional:file:.env[.properties]
+
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:mysql:8:///tripcometrue?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
@@ -13,6 +14,7 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+        default_batch_fetch_size: 200
 
   data:
     redis:
@@ -77,3 +79,8 @@ cloud:
       static: ${AWS_S3_REGION}
     s3:
       bucket: ${AWS_S3_DEV_BUCKET}
+
+exchange-rate:
+  api:
+    url: ${EXCHANGE_RATE_API_URL}
+    key: ${EXCHANGE_RATE_API_KEY}


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)


- **간략한 설명**:
  : 도시 상세 피드 API 1차 구현입니다.
   - 도시 기본 정보 조회
   - 도시 환율 정보 조회
   - 환율 API 호출 로직 구현
   - 환율 업데이트 스케줄러 구현
   - 도시 날씨 정보 조회


---

## 🛠 작성/변경 사항

- ### 변경 사항
   - Place 엔티티에 City 엔티티가 `@ManyToOne`으로 연관관계를 추가했습니다.
      - 그에 따른 파일 수정이 있었습니다.
     

---

## 🔗 관련 이슈

- **이슈 링크** : #55 


---

## 💡 특이 사항

- **주목할 사항** 
  - Redis TestContainers 설정을 작성한 추상 클래스 'AbstractContainersSupport'를 test/config 디렉토리에 추가했습니다.
     - `@SpringBootTest` 테스트의 경우 'AbstractContainersSupport'를 extends 해야 에러가 발생하지 않습니다!
    

---

## 🧪 테스트

- CityService, WeaherRepository Unit 테스트 작성 및 정상 동작 확인 



This close #55 
