### PR TITLE
[feat] 여행 계획,후기 수정및 삭제 관련 api 추가 및 여행후기를 여행계획으로 복사해 오는 api 추가

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
@@ -7,6 +7,8 @@ import com.haejwo.tripcometrue.global.util.ResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,12 +22,25 @@ public class TripPlanController {
     private final TripPlanService tripPlanService;
 
     @PostMapping
-    public ResponseEntity<ResponseDTO<Void>> tripPlanAdd(
+    public ResponseEntity<ResponseDTO<Void>> createTripPlan(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @RequestBody TripPlanRequestDto requestDto
     ) {
 
         tripPlanService.addTripPlan(principalDetails, requestDto);
+        ResponseDTO<Void> responseBody = ResponseDTO.ok();
+
+        return ResponseEntity
+            .status(responseBody.getCode())
+            .body(responseBody);
+    }
+
+    @DeleteMapping("/{planId}")
+    public ResponseEntity<ResponseDTO<Void>> deleteTripPlan(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @PathVariable String planId) {
+
+        tripPlanService.deleteTripPlan(principalDetails, planId);
         ResponseDTO<Void> responseBody = ResponseDTO.ok();
 
         return ResponseEntity

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.tripplan.controller;
 
 import com.haejwo.tripcometrue.domain.tripplan.dto.request.TripPlanRequestDto;
+import com.haejwo.tripcometrue.domain.tripplan.dto.response.CopyTripPlanFromTripRecordResponseDto;
 import com.haejwo.tripcometrue.domain.tripplan.dto.response.TripPlanDetailsResponseDto;
 import com.haejwo.tripcometrue.domain.tripplan.sevice.TripPlanService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
@@ -71,6 +72,19 @@ public class TripPlanController {
 
         ResponseDTO<TripPlanDetailsResponseDto> responseBody = ResponseDTO.okWithData(
             tripPlanService.getTripPlanDetails(planId));
+
+        return ResponseEntity
+            .status(responseBody.getCode())
+            .body(responseBody);
+    }
+
+    @PostMapping("from-trip-record/{tripRecordId}")
+    public ResponseEntity<ResponseDTO<CopyTripPlanFromTripRecordResponseDto>> copyTripPlanFromTripRecord(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @PathVariable Long tripRecordId) {
+
+        ResponseDTO<CopyTripPlanFromTripRecordResponseDto> responseBody = ResponseDTO.okWithData(
+            tripPlanService.copyTripPlanFromTripRecord(tripRecordId, principalDetails));
 
         return ResponseEntity
             .status(responseBody.getCode())

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.tripplan.controller;
 
 import com.haejwo.tripcometrue.domain.tripplan.dto.request.TripPlanRequestDto;
+import com.haejwo.tripcometrue.domain.tripplan.dto.response.TripPlanDetailsResponseDto;
 import com.haejwo.tripcometrue.domain.tripplan.sevice.TripPlanService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -39,7 +41,7 @@ public class TripPlanController {
     @DeleteMapping("/{planId}")
     public ResponseEntity<ResponseDTO<Void>> deleteTripPlan(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @PathVariable String planId) {
+        @PathVariable Long planId) {
 
         tripPlanService.deleteTripPlan(principalDetails, planId);
         ResponseDTO<Void> responseBody = ResponseDTO.ok();
@@ -53,10 +55,22 @@ public class TripPlanController {
     public ResponseEntity<ResponseDTO<Void>> modifyTripPlan(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @RequestBody TripPlanRequestDto requestDto,
-        @PathVariable String planId) {
+        @PathVariable Long planId) {
 
         tripPlanService.modifyTripPlan(principalDetails, planId, requestDto);
         ResponseDTO<Void> responseBody = ResponseDTO.ok();
+
+        return ResponseEntity
+            .status(responseBody.getCode())
+            .body(responseBody);
+    }
+
+    @GetMapping("/{planId}")
+    public ResponseEntity<ResponseDTO<TripPlanDetailsResponseDto>> getTripPlanDetails(
+        @PathVariable Long planId) {
+
+        ResponseDTO<TripPlanDetailsResponseDto> responseBody = ResponseDTO.okWithData(
+            tripPlanService.getTripPlanDetails(planId));
 
         return ResponseEntity
             .status(responseBody.getCode())

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,6 +42,20 @@ public class TripPlanController {
         @PathVariable String planId) {
 
         tripPlanService.deleteTripPlan(principalDetails, planId);
+        ResponseDTO<Void> responseBody = ResponseDTO.ok();
+
+        return ResponseEntity
+            .status(responseBody.getCode())
+            .body(responseBody);
+    }
+
+    @PutMapping("/{planId}")
+    public ResponseEntity<ResponseDTO<Void>> modifyTripPlan(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody TripPlanRequestDto requestDto,
+        @PathVariable String planId) {
+
+        tripPlanService.modifyTripPlan(principalDetails, planId, requestDto);
         ResponseDTO<Void> responseBody = ResponseDTO.ok();
 
         return ResponseEntity

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanControllerAdvice.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanControllerAdvice.java
@@ -1,9 +1,23 @@
 package com.haejwo.tripcometrue.domain.tripplan.controller;
 
+import com.haejwo.tripcometrue.domain.tripplan.exception.TripPlanNotFoundException;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class TripPlanControllerAdvice {
 
+    @ExceptionHandler(TripPlanNotFoundException.class)
+    public ResponseEntity<ResponseDTO<Void>> TripPlanNotFoundException(
+        TripPlanNotFoundException e
+    ) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
 
+        return ResponseEntity
+            .status(status)
+            .body(ResponseDTO.errorWithMessage(status, e.getMessage()));
+    }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/request/TripPlanScheduleRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/request/TripPlanScheduleRequestDto.java
@@ -1,6 +1,5 @@
 package com.haejwo.tripcometrue.domain.tripplan.dto.request;
 
-import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlan;
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlanSchedule;
 import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExternalLinkTagType;
@@ -19,7 +18,7 @@ public record TripPlanScheduleRequestDto(
     String tagUrl
 ) {
 
-    public TripPlanSchedule toEntity(TripPlan tripPlan, Member member) {
+    public TripPlanSchedule toEntity(TripPlan tripPlan) {
         return TripPlanSchedule.builder()
             .dayNumber(this.dayNumber)
             .ordering(this.orderNumber)
@@ -28,7 +27,6 @@ public record TripPlanScheduleRequestDto(
             .tripPlan(tripPlan)
             .tagType(this.tagType)
             .tagUrl(this.tagUrl)
-            .member(member)
             .build();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/CopyTripPlanFromTripRecordResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/CopyTripPlanFromTripRecordResponseDto.java
@@ -1,0 +1,24 @@
+package com.haejwo.tripcometrue.domain.tripplan.dto.response;
+
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import java.time.LocalDate;
+import java.util.List;
+
+public record CopyTripPlanFromTripRecordResponseDto(
+
+    String countries,
+    LocalDate tripStartDay,
+    LocalDate tripEndDay,
+    List<TripPlanScheduleResponseDto> tripSchedules
+) {
+
+    public static CopyTripPlanFromTripRecordResponseDto fromEntity(TripRecord tripRecord,
+        List<TripPlanScheduleResponseDto> tripSchedules) {
+        return new CopyTripPlanFromTripRecordResponseDto(
+            tripRecord.getCountries(),
+            tripRecord.getTripStartDay(),
+            tripRecord.getTripEndDay(),
+            tripSchedules
+        );
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/TripPlanDetailsResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/TripPlanDetailsResponseDto.java
@@ -1,0 +1,24 @@
+package com.haejwo.tripcometrue.domain.tripplan.dto.response;
+
+import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlan;
+import java.time.LocalDate;
+import java.util.List;
+
+public record TripPlanDetailsResponseDto(
+
+    String countries,
+    LocalDate tripStartDay,
+    LocalDate tripEndDay,
+    List<TripPlanScheduleResponseDto> tripPlanSchedules
+) {
+
+    public static TripPlanDetailsResponseDto fromEntity(TripPlan tripPlan,
+        List<TripPlanScheduleResponseDto> tripPlanSchedules) {
+        return new TripPlanDetailsResponseDto(
+            tripPlan.getCountries(),
+            tripPlan.getTripStartDay(),
+            tripPlan.getTripEndDay(),
+            tripPlanSchedules
+        );
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/TripPlanScheduleResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/TripPlanScheduleResponseDto.java
@@ -1,0 +1,39 @@
+package com.haejwo.tripcometrue.domain.tripplan.dto.response;
+
+import com.haejwo.tripcometrue.domain.place.entity.Place;
+import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlanSchedule;
+import com.haejwo.tripcometrue.global.enums.Country;
+
+public record TripPlanScheduleResponseDto(
+
+    Double latitude,
+    Double longitude,
+    Country country,
+    String cityName,
+    String placeName,
+    Integer dayNumber,
+    Integer orderNumber,
+    Long placeId,
+    String content,
+    String tagType,
+    String tagUrl
+
+) {
+
+    public static TripPlanScheduleResponseDto fromEntity(TripPlanSchedule tripPlanSchedule,
+        Place place) {
+        return new TripPlanScheduleResponseDto(
+            place.getLatitude(),
+            place.getLongitude(),
+            place.getCity().getCountry(),
+            place.getCity().getName(),
+            place.getName(),
+            tripPlanSchedule.getDayNumber(),
+            tripPlanSchedule.getOrdering(),
+            place.getId(),
+            tripPlanSchedule.getContent(),
+            tripPlanSchedule.getTagType().name(),
+            tripPlanSchedule.getTagUrl()
+        );
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/TripPlanScheduleResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/TripPlanScheduleResponseDto.java
@@ -2,6 +2,7 @@ package com.haejwo.tripcometrue.domain.tripplan.dto.response;
 
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlanSchedule;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordSchedule;
 import com.haejwo.tripcometrue.global.enums.Country;
 
 public record TripPlanScheduleResponseDto(
@@ -34,6 +35,23 @@ public record TripPlanScheduleResponseDto(
             tripPlanSchedule.getContent(),
             tripPlanSchedule.getTagType().name(),
             tripPlanSchedule.getTagUrl()
+        );
+    }
+
+    public static TripPlanScheduleResponseDto fromEntity(TripRecordSchedule tripRecordSchedule,
+        Place place) {
+        return new TripPlanScheduleResponseDto(
+            place.getLatitude(),
+            place.getLongitude(),
+            place.getCity().getCountry(),
+            place.getCity().getName(),
+            place.getName(),
+            tripRecordSchedule.getDayNumber(),
+            tripRecordSchedule.getOrdering(),
+            place.getId(),
+            tripRecordSchedule.getContent(),
+            tripRecordSchedule.getTagType().name(),
+            tripRecordSchedule.getTagUrl()
         );
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/TripPlanScheduleResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/response/TripPlanScheduleResponseDto.java
@@ -3,6 +3,7 @@ package com.haejwo.tripcometrue.domain.tripplan.dto.response;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlanSchedule;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordSchedule;
+import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExternalLinkTagType;
 import com.haejwo.tripcometrue.global.enums.Country;
 
 public record TripPlanScheduleResponseDto(
@@ -16,7 +17,7 @@ public record TripPlanScheduleResponseDto(
     Integer orderNumber,
     Long placeId,
     String content,
-    String tagType,
+    ExternalLinkTagType tagType,
     String tagUrl
 
 ) {
@@ -33,7 +34,7 @@ public record TripPlanScheduleResponseDto(
             tripPlanSchedule.getOrdering(),
             place.getId(),
             tripPlanSchedule.getContent(),
-            tripPlanSchedule.getTagType().name(),
+            tripPlanSchedule.getTagType(),
             tripPlanSchedule.getTagUrl()
         );
     }
@@ -50,7 +51,7 @@ public record TripPlanScheduleResponseDto(
             tripRecordSchedule.getOrdering(),
             place.getId(),
             tripRecordSchedule.getContent(),
-            tripRecordSchedule.getTagType().name(),
+            tripRecordSchedule.getTagType(),
             tripRecordSchedule.getTagUrl()
         );
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/entity/TripPlan.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/entity/TripPlan.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.tripplan.entity;
 
 import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.tripplan.dto.request.TripPlanRequestDto;
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -59,5 +60,11 @@ public class TripPlan extends BaseTimeEntity {
         this.tripPlanSchedules = tripRecordSchedules;
         this.member = member;
         this.referencedBy = referencedBy;
+    }
+
+    public void update(TripPlanRequestDto requestDto) {
+        this.countries = requestDto.countries();
+        this.tripStartDay = requestDto.tripStartDay();
+        this.tripEndDay = requestDto.tripEndDay();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/entity/TripPlan.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/entity/TripPlan.java
@@ -56,7 +56,7 @@ public class TripPlan extends BaseTimeEntity {
         this.tripEndDay = tripEndDay;
         this.totalDays = totalDays;
         this.averageRating = averageRating;
-        this.viewCount = viewCount;
+        this.viewCount = 0;
         this.tripPlanSchedules = tripRecordSchedules;
         this.member = member;
         this.referencedBy = referencedBy;

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/entity/TripPlanSchedule.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/entity/TripPlanSchedule.java
@@ -1,6 +1,5 @@
 package com.haejwo.tripcometrue.domain.tripplan.entity;
 
-import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExternalLinkTagType;
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
@@ -44,14 +43,10 @@ public class TripPlanSchedule extends BaseTimeEntity {
     private ExternalLinkTagType tagType;
     private String tagUrl;
 
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
-
     @Builder
     public TripPlanSchedule(Integer dayNumber, Integer ordering, String content,
-        Long placeId, TripPlan tripPlan, ExternalLinkTagType tagType, String tagUrl,
-        Member member) {
+        Long placeId, TripPlan tripPlan, ExternalLinkTagType tagType, String tagUrl
+    ) {
         this.dayNumber = dayNumber;
         this.ordering = ordering;
         this.content = content;
@@ -59,7 +54,5 @@ public class TripPlanSchedule extends BaseTimeEntity {
         this.tripPlan = tripPlan;
         this.tagType = tagType;
         this.tagUrl = tagUrl;
-        this.member = member;
-
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/exception/TripPlanNotFoundException.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/exception/TripPlanNotFoundException.java
@@ -1,0 +1,13 @@
+package com.haejwo.tripcometrue.domain.tripplan.exception;
+
+import com.haejwo.tripcometrue.global.exception.ApplicationException;
+import com.haejwo.tripcometrue.global.exception.ErrorCode;
+
+public class TripPlanNotFoundException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.TRIP_PLAN_NOT_FOUND;
+
+    public TripPlanNotFoundException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/repository/TripPlanScheduleRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/repository/TripPlanScheduleRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripPlanScheduleRepository extends JpaRepository<TripPlanSchedule, Long> {
 
+    void deleteAllByTripPlanId(Long tripPlanId);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/repository/TripPlanScheduleRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/repository/TripPlanScheduleRepository.java
@@ -1,9 +1,12 @@
 package com.haejwo.tripcometrue.domain.tripplan.repository;
 
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlanSchedule;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripPlanScheduleRepository extends JpaRepository<TripPlanSchedule, Long> {
 
     void deleteAllByTripPlanId(Long tripPlanId);
+
+    List<TripPlanSchedule> findAllByTripPlanId(Long tripPlanId);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/sevice/TripPlanService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/sevice/TripPlanService.java
@@ -4,6 +4,7 @@ import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.place.exception.PlaceNotFoundException;
 import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
 import com.haejwo.tripcometrue.domain.tripplan.dto.request.TripPlanRequestDto;
+import com.haejwo.tripcometrue.domain.tripplan.dto.request.TripPlanScheduleRequestDto;
 import com.haejwo.tripcometrue.domain.tripplan.dto.response.TripPlanDetailsResponseDto;
 import com.haejwo.tripcometrue.domain.tripplan.dto.response.TripPlanScheduleResponseDto;
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlan;
@@ -28,6 +29,7 @@ public class TripPlanService {
 
     @Transactional
     public void addTripPlan(PrincipalDetails principalDetails, TripPlanRequestDto requestDto) {
+        validatePlaceId(requestDto.tripPlanSchedules());
         TripPlan requestTripPlan = requestDto.toEntity(principalDetails.getMember());
         tripPlanRepository.save(requestTripPlan);
 
@@ -53,6 +55,7 @@ public class TripPlanService {
     public void modifyTripPlan(PrincipalDetails principalDetails, Long planId,
         TripPlanRequestDto requestDto) {
 
+        validatePlaceId(requestDto.tripPlanSchedules());
         TripPlan tripPlan = tripPlanRepository.findById(planId)
             .orElseThrow(TripPlanNotFoundException::new);
 
@@ -86,5 +89,12 @@ public class TripPlanService {
             .collect(Collectors.toList());
 
         return TripPlanDetailsResponseDto.fromEntity(tripPlan, responseDtos);
+    }
+
+    private void validatePlaceId(List<TripPlanScheduleRequestDto> tripPlanSchedules) {
+        for (TripPlanScheduleRequestDto tripPlanSchedule : tripPlanSchedules) {
+            placeRepository.findById(tripPlanSchedule.placeId())
+                .orElseThrow(PlaceNotFoundException::new);
+        }
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/sevice/TripPlanService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/sevice/TripPlanService.java
@@ -2,8 +2,10 @@ package com.haejwo.tripcometrue.domain.tripplan.sevice;
 
 import com.haejwo.tripcometrue.domain.tripplan.dto.request.TripPlanRequestDto;
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlan;
+import com.haejwo.tripcometrue.domain.tripplan.exception.TripPlanNotFoundException;
 import com.haejwo.tripcometrue.domain.tripplan.repository.TripPlanRepository;
 import com.haejwo.tripcometrue.domain.tripplan.repository.TripPlanScheduleRepository;
+import com.haejwo.tripcometrue.global.exception.PermissionDeniedException;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,5 +27,17 @@ public class TripPlanService {
             .map(tripPlanScheduleRequestDto ->
                 tripPlanScheduleRequestDto.toEntity(requestTripPlan, principalDetails.getMember()))
             .forEach(tripPlanScheduleRepository::save);
+    }
+
+    public void deleteTripPlan(PrincipalDetails principalDetails, String planId) {
+
+        TripPlan tripPlan = tripPlanRepository.findById(Long.parseLong(planId))
+            .orElseThrow(TripPlanNotFoundException::new);
+
+        if (!tripPlan.getMember().getId().equals(principalDetails.getMember().getId())) {
+            throw new PermissionDeniedException();
+        }
+
+        tripPlanRepository.delete(tripPlan);
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/sevice/TripPlanService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/sevice/TripPlanService.java
@@ -25,7 +25,7 @@ public class TripPlanService {
 
         requestDto.tripPlanSchedules().stream()
             .map(tripPlanScheduleRequestDto ->
-                tripPlanScheduleRequestDto.toEntity(requestTripPlan, principalDetails.getMember()))
+                tripPlanScheduleRequestDto.toEntity(requestTripPlan))
             .forEach(tripPlanScheduleRepository::save);
     }
 
@@ -42,7 +42,8 @@ public class TripPlanService {
     }
 
     @Transactional
-    public void modifyTripPlan(PrincipalDetails principalDetails, String planId, TripPlanRequestDto requestDto) {
+    public void modifyTripPlan(PrincipalDetails principalDetails, String planId,
+        TripPlanRequestDto requestDto) {
 
         TripPlan tripPlan = tripPlanRepository.findById(Long.parseLong(planId))
             .orElseThrow(TripPlanNotFoundException::new);
@@ -57,7 +58,7 @@ public class TripPlanService {
         tripPlanScheduleRepository.deleteAllByTripPlanId(tripPlan.getId());
         requestDto.tripPlanSchedules().stream()
             .map(tripPlanScheduleRequestDto ->
-                tripPlanScheduleRequestDto.toEntity(tripPlan, principalDetails.getMember()))
+                tripPlanScheduleRequestDto.toEntity(tripPlan))
             .forEach(tripPlanScheduleRepository::save);
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
@@ -39,7 +39,8 @@ public class TripRecordController {
         @PathVariable Long tripRecordId
     ) {
 
-        TripRecordDetailResponseDto responseDto = tripRecordService.findTripRecord(principalDetails, tripRecordId);
+        TripRecordDetailResponseDto responseDto = tripRecordService.findTripRecord(principalDetails,
+            tripRecordId);
         ResponseDTO<TripRecordDetailResponseDto> responseBody = ResponseDTO.okWithData(responseDto);
 
         return ResponseEntity
@@ -56,42 +57,12 @@ public class TripRecordController {
         List<TripRecordListResponseDto> responseDtos
             = tripRecordService.findTripRecordList(pageable, request);
 
-        ResponseDTO<List<TripRecordListResponseDto>> responseBody = ResponseDTO.okWithData(responseDtos);
-
-        return  ResponseEntity
-                    .status(responseBody.getCode())
-                    .body(responseBody);
-
-    }
-
-    @PutMapping("/{tripRecordId}")
-    public ResponseEntity<ResponseDTO<TripRecordResponseDto>> tripRecordModify(
-        @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @PathVariable Long tripRecordId,
-        @RequestBody TripRecordRequestDto requestDto
-    ) {
-
-        TripRecordResponseDto responseDto = tripRecordService.modifyTripRecord(principalDetails, tripRecordId, requestDto);
-        ResponseDTO<TripRecordResponseDto> responseBody = ResponseDTO.okWithData(responseDto);
+        ResponseDTO<List<TripRecordListResponseDto>> responseBody = ResponseDTO.okWithData(
+            responseDtos);
 
         return ResponseEntity
             .status(responseBody.getCode())
             .body(responseBody);
 
     }
-
-    @DeleteMapping("/{tripRecordId}")
-    public ResponseEntity<ResponseDTO> tripRecordRemove(
-        @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @PathVariable Long tripRecordId
-    ) {
-
-        tripRecordService.removeTripRecord(principalDetails, tripRecordId);
-        ResponseDTO responseBody = ResponseDTO.ok();
-
-        return ResponseEntity
-            .status(responseBody.getCode())
-            .body(responseBody);
-    }
-
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordEditController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordEditController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,6 +33,21 @@ public class TripRecordEditController {
     ) {
 
         tripRecordEditService.addTripRecord(principalDetails, requestDto);
+        ResponseDTO<Void> responseBody = ResponseDTO.ok();
+
+        return ResponseEntity
+            .status(responseBody.getCode())
+            .body(responseBody);
+    }
+
+    @PutMapping("/v1/trip-record/{tripRecordId}")
+    public ResponseEntity<ResponseDTO<Void>> modifyTripRecord(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody TripRecordRequestDto requestDto,
+        @PathVariable Long tripRecordId
+    ) {
+
+        tripRecordEditService.modifyTripRecord(principalDetails, requestDto, tripRecordId);
         ResponseDTO<Void> responseBody = ResponseDTO.ok();
 
         return ResponseEntity

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordEditController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordEditController.java
@@ -11,7 +11,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,12 +26,26 @@ public class TripRecordEditController {
     private final TripRecordEditService tripRecordEditService;
 
     @PostMapping("/v1/trip-record")
-    public ResponseEntity<ResponseDTO<Void>> tripRecordAdd(
+    public ResponseEntity<ResponseDTO<Void>> createTripRecord(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @RequestBody TripRecordRequestDto requestDto
     ) {
 
         tripRecordEditService.addTripRecord(principalDetails, requestDto);
+        ResponseDTO<Void> responseBody = ResponseDTO.ok();
+
+        return ResponseEntity
+            .status(responseBody.getCode())
+            .body(responseBody);
+    }
+
+    @DeleteMapping("/v1/trip-record/{tripRecordId}")
+    public ResponseEntity<ResponseDTO<Void>> deleteTripRecord(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @PathVariable Long tripRecordId
+    ) {
+
+        tripRecordEditService.deleteTripRecord(principalDetails, tripRecordId);
         ResponseDTO<Void> responseBody = ResponseDTO.ok();
 
         return ResponseEntity

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordEditControllerAdvice.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordEditControllerAdvice.java
@@ -1,0 +1,23 @@
+package com.haejwo.tripcometrue.domain.triprecord.controller;
+
+import com.haejwo.tripcometrue.global.exception.PermissionDeniedException;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class TripRecordEditControllerAdvice {
+
+    @ExceptionHandler(PermissionDeniedException.class)
+    public ResponseEntity<ResponseDTO<Void>> PermissionDeniedException(
+        PermissionDeniedException e
+    ) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+            .status(status)
+            .body(ResponseDTO.errorWithMessage(status, e.getMessage()));
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/request/CreateSchedulePlaceRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/request/CreateSchedulePlaceRequestDto.java
@@ -1,6 +1,8 @@
 package com.haejwo.tripcometrue.domain.triprecord.dto.request;
 
+import com.haejwo.tripcometrue.domain.city.entity.City;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
+import com.haejwo.tripcometrue.global.enums.Country;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateSchedulePlaceRequestDto(
@@ -12,15 +14,20 @@ public record CreateSchedulePlaceRequestDto(
     @NotNull(message = "latitude은 필수값입니다")
     Double latitude,
     @NotNull(message = "longitude은 필수값입니다")
-    Double longitude
+    Double longitude,
+    @NotNull(message = "country은 필수값입니다")
+    Country country,
+    @NotNull(message = "cityname은 필수값입니다")
+    String cityname
 ) {
 
-    public Place toEntity() {
+    public Place toEntity(City city) {
         return Place.builder()
             .name(this.name)
             .address(this.address)
             .latitude(this.latitude)
             .longitude(this.longitude)
+            .city(city)
             .build();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/request/TripRecordScheduleRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/request/TripRecordScheduleRequestDto.java
@@ -1,6 +1,5 @@
 package com.haejwo.tripcometrue.domain.triprecord.dto.request;
 
-import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordSchedule;
@@ -23,7 +22,7 @@ public record TripRecordScheduleRequestDto(
     String tagUrl
 ) {
 
-    public TripRecordSchedule toEntity(TripRecord tripRecord, Member member, Place place) {
+    public TripRecordSchedule toEntity(TripRecord tripRecord, Place place) {
         return TripRecordSchedule.builder()
             .dayNumber(this.dayNumber)
             .ordering(this.orderNumber)
@@ -32,7 +31,6 @@ public record TripRecordScheduleRequestDto(
             .tripRecord(tripRecord)
             .tagType(this.tagType)
             .tagUrl(this.tagUrl)
-            .member(member)
             .build();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecord.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecord.java
@@ -63,6 +63,9 @@ public class TripRecord extends BaseTimeEntity {
     @OneToMany(mappedBy = "tripRecord", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<TripRecordImage> tripRecordImages = new ArrayList<>();
 
+    @OneToMany(mappedBy = "tripRecord", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private List<TripRecordStore> tripRecordStores = new ArrayList<>();
+
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordSchedule.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordSchedule.java
@@ -1,6 +1,5 @@
 package com.haejwo.tripcometrue.domain.triprecord.entity;
 
-import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExternalLinkTagType;
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
@@ -60,14 +59,9 @@ public class TripRecordSchedule extends BaseTimeEntity {
 
     private String tagUrl;
 
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
-
     @Builder
     public TripRecordSchedule(Integer dayNumber, Integer ordering, String content,
-        Place place, TripRecord tripRecord, ExternalLinkTagType tagType, String tagUrl,
-        Member member) {
+        Place place, TripRecord tripRecord, ExternalLinkTagType tagType, String tagUrl) {
         this.dayNumber = dayNumber;
         this.ordering = ordering;
         this.content = content;
@@ -75,6 +69,5 @@ public class TripRecordSchedule extends BaseTimeEntity {
         this.tripRecord = tripRecord;
         this.tagType = tagType;
         this.tagUrl = tagUrl;
-        this.member = member;
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordStore.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordStore.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TripRecordStore extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_image/TripRecordImageRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_image/TripRecordImageRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripRecordImageRepository extends JpaRepository<TripRecordImage, Long> {
 
+    void deleteAllByTripRecordId(Long recordId);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepository.java
@@ -1,10 +1,12 @@
 package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule;
 
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordSchedule;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripRecordScheduleRepository extends JpaRepository<TripRecordSchedule, Long> {
 
 
+    List<TripRecordSchedule> findAllByTripRecordId(Long recordId);
     void deleteAllByTripRecordId(Long recordId);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripRecordScheduleRepository extends JpaRepository<TripRecordSchedule, Long> {
 
+
+    void deleteAllByTripRecordId(Long recordId);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_store/TripRecordStoreRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_store/TripRecordStoreRepository.java
@@ -1,0 +1,9 @@
+package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_store;
+
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordStore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRecordStoreRepository extends
+    JpaRepository<TripRecordStore, Long> {
+
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_tag/TripRecordTagRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_tag/TripRecordTagRepository.java
@@ -1,9 +1,9 @@
 package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_tag;
 
-import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordImage;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripRecordTagRepository extends JpaRepository<TripRecordTag, Long> {
 
+    void deleteAllByTripRecordId(Long TripRecordId);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
@@ -50,6 +50,7 @@ public class TripRecordEditService {
 
     @Transactional
     public void addTripRecord(PrincipalDetails principalDetails, TripRecordRequestDto requestDto) {
+        validatePlaceId(requestDto.tripRecordSchedules());
         TripRecord requestTripRecord = requestDto.toEntity(principalDetails.getMember());
         tripRecordRepository.save(requestTripRecord);
 
@@ -144,6 +145,7 @@ public class TripRecordEditService {
     public void modifyTripRecord(PrincipalDetails principalDetails,
         TripRecordRequestDto requestDto, Long tripRecordId) {
 
+        validatePlaceId(requestDto.tripRecordSchedules());
         Optional<TripRecord> tripRecord = tripRecordRepository.findById(tripRecordId);
 
         if (tripRecord.isPresent()) {
@@ -170,5 +172,13 @@ public class TripRecordEditService {
         tripRecordImageRepository.deleteAllByTripRecordId(foundTripRecord.getId());
         tripRecordTagRepository.deleteAllByTripRecordId(foundTripRecord.getId());
         tripRecordScheduleRepository.deleteAllByTripRecordId(foundTripRecord.getId());
+    }
+
+    private void validatePlaceId(
+        List<TripRecordScheduleRequestDto> tripRecordScheduleRequestDtoList) {
+        for (TripRecordScheduleRequestDto tripRecordScheduleRequestDto : tripRecordScheduleRequestDtoList) {
+            placeRepository.findById(tripRecordScheduleRequestDto.placeId())
+                .orElseThrow(PlaceNotFoundException::new);
+        }
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
@@ -1,7 +1,6 @@
 package com.haejwo.tripcometrue.domain.triprecord.service;
 
 import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
-import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.place.exception.PlaceNotFoundException;
 import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
@@ -54,7 +53,7 @@ public class TripRecordEditService {
 
         saveTripRecordImages(requestDto, requestTripRecord);
         saveHashTags(requestDto, requestTripRecord);
-        saveTripRecordSchedules(requestDto, requestTripRecord, principalDetails.getMember());
+        saveTripRecordSchedules(requestDto, requestTripRecord);
     }
 
     private void saveTripRecordImages(TripRecordRequestDto requestDto,
@@ -74,13 +73,13 @@ public class TripRecordEditService {
     }
 
     private void saveTripRecordSchedules(TripRecordRequestDto requestDto,
-        TripRecord requestTripRecord, Member member) {
+        TripRecord requestTripRecord) {
         requestDto.tripRecordSchedules().forEach(tripRecordScheduleRequestDto -> {
             Place place = placeRepository.findById(tripRecordScheduleRequestDto.placeId())
                 .orElseThrow(PlaceNotFoundException::new);
 
             TripRecordSchedule tripRecordSchedule = tripRecordScheduleRequestDto.toEntity(
-                requestTripRecord, member, place);
+                requestTripRecord, place);
             tripRecordScheduleRepository.save(tripRecordSchedule);
 
             saveTripRecordScheduleImages(tripRecordScheduleRequestDto, tripRecordSchedule);
@@ -152,7 +151,7 @@ public class TripRecordEditService {
                 deleteTripRecordAssociations(foundTripRecord);
                 saveTripRecordImages(requestDto, foundTripRecord);
                 saveHashTags(requestDto, foundTripRecord);
-                saveTripRecordSchedules(requestDto, foundTripRecord, principalDetails.getMember());
+                saveTripRecordSchedules(requestDto, foundTripRecord);
 
             } else {
                 throw new PermissionDeniedException();

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
@@ -1,5 +1,7 @@
 package com.haejwo.tripcometrue.domain.triprecord.service;
 
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.exception.CityNotFoundException;
 import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.place.exception.PlaceNotFoundException;
@@ -115,7 +117,10 @@ public class TripRecordEditService {
     }
 
     public Long createSchedulePlace(CreateSchedulePlaceRequestDto createSchedulePlaceRequestDto) {
-        return placeRepository.save(createSchedulePlaceRequestDto.toEntity()).getId();
+        City city = cityRepository.findByNameAndCountry(createSchedulePlaceRequestDto.cityname(),
+            createSchedulePlaceRequestDto.country()).orElseThrow(CityNotFoundException::new);
+
+        return placeRepository.save(createSchedulePlaceRequestDto.toEntity(city)).getId();
     }
 
     @Transactional

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
@@ -135,4 +135,36 @@ public class TripRecordEditService {
             throw new TripRecordNotFoundException();
         }
     }
+
+    @Transactional
+    public void modifyTripRecord(PrincipalDetails principalDetails,
+        TripRecordRequestDto requestDto, Long tripRecordId) {
+
+        Optional<TripRecord> tripRecord = tripRecordRepository.findById(tripRecordId);
+
+        if (tripRecord.isPresent()) {
+            TripRecord foundTripRecord = tripRecord.get();
+            if (foundTripRecord.getMember().getId().equals(principalDetails.getMember().getId())) {
+
+                foundTripRecord.update(requestDto);
+                tripRecordRepository.save(foundTripRecord);
+
+                deleteTripRecordAssociations(foundTripRecord);
+                saveTripRecordImages(requestDto, foundTripRecord);
+                saveHashTags(requestDto, foundTripRecord);
+                saveTripRecordSchedules(requestDto, foundTripRecord, principalDetails.getMember());
+
+            } else {
+                throw new PermissionDeniedException();
+            }
+        } else {
+            throw new TripRecordNotFoundException();
+        }
+    }
+
+    private void deleteTripRecordAssociations(TripRecord foundTripRecord) {
+        tripRecordImageRepository.deleteAllByTripRecordId(foundTripRecord.getId());
+        tripRecordTagRepository.deleteAllByTripRecordId(foundTripRecord.getId());
+        tripRecordScheduleRepository.deleteAllByTripRecordId(foundTripRecord.getId());
+    }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -61,33 +61,6 @@ public class TripRecordService {
     }
 
     @Transactional
-    public TripRecordResponseDto modifyTripRecord(PrincipalDetails principalDetails, Long tripRecordId, TripRecordRequestDto requestDto) {
-
-        TripRecord findTripRecord =  findTripRecordById(tripRecordId);
-
-        if(principalDetails.getMember().getId() != findTripRecord.getMember().getId()) {
-            throw new UserInvalidAccessException();
-        }
-        
-        findTripRecord.update(requestDto);
-        TripRecordResponseDto responseDto = TripRecordResponseDto.fromEntity(findTripRecord);
-
-        return responseDto;
-    }
-
-    @Transactional
-    public void removeTripRecord(PrincipalDetails principalDetails, Long tripRecordId) {
-
-        TripRecord findTripRecord = findTripRecordById(tripRecordId);
-
-        if(principalDetails.getMember().getId() != findTripRecord.getMember().getId()) {
-            throw new UserInvalidAccessException();
-        }
-
-        tripRecordRepository.delete(findTripRecord);
-    }
-
-    @Transactional
     public void incrementViewCount(TripRecord tripRecord) {
 
         LocalDate today = LocalDate.now();

--- a/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
@@ -38,6 +38,9 @@ public enum ErrorCode {
     TRIP_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행후기입니다."),
     EXPENSE_RANGE_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 비용범위입니다."),
 
+    // TRIP_PLAN
+    TRIP_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행계획입니다."),
+
     // Likes
     LIKES_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요 데이터가 존재하지 않습니다."),
     LIKES_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 좋아요가 등록되어 있습니다."),

--- a/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
@@ -11,6 +11,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
+    // Permission
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 작업을 수행할 권한이 업습니다."),
+
     // EMAIL
     EMAIL_SENDING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
     EMAIL_TEMPLATE_LOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 템플릿 로드에 실패했습니다."),

--- a/src/main/java/com/haejwo/tripcometrue/global/exception/PermissionDeniedException.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/exception/PermissionDeniedException.java
@@ -1,0 +1,11 @@
+package com.haejwo.tripcometrue.global.exception;
+
+
+public class PermissionDeniedException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.PERMISSION_DENIED;
+
+    public PermissionDeniedException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/springsecurity/SpringSecurityConfig.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/springsecurity/SpringSecurityConfig.java
@@ -79,6 +79,8 @@ public class SpringSecurityConfig {
             .requestMatchers(new AntPathRequestMatcher("/v1/trip-records/**")).permitAll()
             .requestMatchers(new AntPathRequestMatcher("/v1/search-schedule-places/**")).permitAll()
             .requestMatchers(new AntPathRequestMatcher("/v1/schedule-place/**")).permitAll()
+            .requestMatchers(new AntPathRequestMatcher("/v1/trip-plan/{planId}")).permitAll()
+
 
             .anyRequest().authenticated());
 

--- a/src/test/http/trip_plan/trip_plan.http
+++ b/src/test/http/trip_plan/trip_plan.http
@@ -28,6 +28,35 @@ Content-Type: application/json
   ]
 }
 
+### 여행 계획 수정
+PUT http://localhost:8080/v1/trip-plan/4
+Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
+Content-Type: application/json
+
+{
+  "countries": "한국,일본,중국",
+  "tripStartDay": "2024-01-10",
+  "tripEndDay": "2024-01-20",
+  "tripPlanSchedules": [
+    {
+      "dayNumber": 1,
+      "orderNumber": 1,
+      "placeId": 2,
+      "content": "수정 방문한 장소에 대한 메모나 정보",
+      "tagType": "AIRLINE_TICKET_PURCHASE",
+      "tagUrl": "수정 스케줄 태그 링크1"
+    },
+    {
+      "dayNumber": 1,
+      "orderNumber": 2,
+      "placeId": 2,
+      "content": "수정 내용",
+      "tagType": "AIRLINE_TICKET_PURCHASE",
+      "tagUrl": "수정 스케줄 태그 링크2"
+    }
+  ]
+}
+
 ### 여행 계획 삭제
 DELETE http://localhost:8080/v1/trip-plan/1
 Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI

--- a/src/test/http/trip_plan/trip_plan.http
+++ b/src/test/http/trip_plan/trip_plan.http
@@ -29,7 +29,7 @@ Content-Type: application/json
 }
 
 ### 여행 계획 수정
-PUT http://localhost:8080/v1/trip-plan/4
+PUT http://localhost:8080/v1/trip-plan/1
 Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
 Content-Type: application/json
 
@@ -60,3 +60,6 @@ Content-Type: application/json
 ### 여행 계획 삭제
 DELETE http://localhost:8080/v1/trip-plan/1
 Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
+
+### 여행 계획 조회
+GET http://localhost:8080/v1/trip-plan/1

--- a/src/test/http/trip_plan/trip_plan.http
+++ b/src/test/http/trip_plan/trip_plan.http
@@ -1,7 +1,7 @@
 
 ### 여행 계획 작성
 POST http://localhost:8080/v1/trip-plan
-Authorization: eyJraWQiOiJrZXkxIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDQ4ODAwNTUsImV4cCI6MTcwNTAyNDA1NX0.CxgA80_iaos4nyeYoV49Du4bpWezOuVjAnTT3qXfawI
+Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
 Content-Type: application/json
 
 {
@@ -27,3 +27,7 @@ Content-Type: application/json
     }
   ]
 }
+
+### 여행 계획 삭제
+DELETE http://localhost:8080/v1/trip-plan/1
+Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI

--- a/src/test/http/trip_plan/trip_plan.http
+++ b/src/test/http/trip_plan/trip_plan.http
@@ -63,3 +63,7 @@ Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci
 
 ### 여행 계획 조회
 GET http://localhost:8080/v1/trip-plan/1
+
+### 여행 계획 복사
+POST http://localhost:8080/v1/trip-plan/from-trip-record/1
+Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI

--- a/src/test/http/trip_record/trip_record_edit.http
+++ b/src/test/http/trip_record/trip_record_edit.http
@@ -1,6 +1,6 @@
 ### 여행후기 저장
 POST http://localhost:8080/v1/trip-record
-Authorization: eyJraWQiOiJrZXkxIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDQ4ODAwNTUsImV4cCI6MTcwNTAyNDA1NX0.CxgA80_iaos4nyeYoV49Du4bpWezOuVjAnTT3qXfawI
+Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
 Content-Type: application/json
 
 {
@@ -63,6 +63,10 @@ Content-Type: application/json
     }
   ]
 }
+
+### 여행후기 삭제
+DELETE http://localhost:8080/v1/trip-record/10
+Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
 
 ### 여행스케줄 장소 검색하기
 GET http://localhost:8080/v1/search-schedule-places?country=KOREA&city=서울

--- a/src/test/http/trip_record/trip_record_edit.http
+++ b/src/test/http/trip_record/trip_record_edit.http
@@ -65,8 +65,75 @@ Content-Type: application/json
 }
 
 ### 여행후기 삭제
-DELETE http://localhost:8080/v1/trip-record/10
+DELETE http://localhost:8080/v1/trip-record/1
 Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
+
+### 여행후기 수정
+PUT http://localhost:8080/v1/trip-record/1
+Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
+Content-Type: application/json
+
+{
+  "tripRecordImages": [
+    {
+      "imageUrl": "수정 이미지링크1",
+      "tagType": "FOOD_TOURISM_LOCATION",
+      "tagUrl": "수정 주소1"
+    },
+    {
+      "imageUrl": "수정 이미지링크1",
+      "tagType": "AIRLINE_TICKET_PURCHASE",
+      "tagUrl": "수정 주소1"
+    }
+  ],
+  "title": "수정 피드 제목",
+  "content": "수정 여행의 전반적인 후기나 메모",
+  "expenseRangeType": "BELOW_50",
+  "hashTags": [
+    "연인끼리",
+    "친구끼리",
+    "혼자여행",
+    "가족여행"
+  ],
+  "countries": "한국,일본",
+  "tripStartDay": "2024-01-10",
+  "tripEndDay": "2024-01-20",
+  "tripRecordSchedules": [
+    {
+      "dayNumber": 1,
+      "orderNumber": 1,
+      "placeId": 2,
+      "content": "수정 방문한 장소에 대한 메모나 정보",
+      "tripRecordScheduleImages": [
+        "수정 스케줄 이미지 링크1",
+        "수정 스케줄 이미지 링크2",
+        "수정 스케줄 이미지 링크2"
+      ],
+      "tripRecordScheduleVideos": [
+        "수정 스케줄 비디오 링크1"
+      ],
+      "tagType": "AIRLINE_TICKET_PURCHASE",
+      "tagUrl": "수정 스케줄 태그 링크1"
+    },
+    {
+      "dayNumber": 1,
+      "orderNumber": 2,
+      "placeId": 2,
+      "content": "수정 내용",
+      "tripRecordScheduleImages": [
+        "수정 스케줄 이미지 링크3",
+        "수정 스케줄 이미지 링크4"
+      ],
+      "tripRecordScheduleVideos": [
+        "수정 스케줄 비디오 링크4",
+        "수정 스케줄 비디오 링크5",
+        "수정 스케줄 비디오 링크6"
+      ],
+      "tagType": "AIRLINE_TICKET_PURCHASE",
+      "tagUrl": "수정 스케줄 태그 링크2"
+    }
+  ]
+}
 
 ### 여행스케줄 장소 검색하기
 GET http://localhost:8080/v1/search-schedule-places?country=KOREA&city=서울

--- a/src/test/http/trip_record/trip_record_edit.http
+++ b/src/test/http/trip_record/trip_record_edit.http
@@ -146,5 +146,7 @@ Content-Type: application/json
   "address": "서울특별시 강남구 테헤란로 427",
   "name": "강남역",
   "latitude": 37.498085,
-  "longitude": 127.027486
+  "longitude": 127.027486,
+  "country": "KOREA",
+  "cityname": "서울"
 }

--- a/src/test/http/trip_record/trip_record_edit.http
+++ b/src/test/http/trip_record/trip_record_edit.http
@@ -6,18 +6,18 @@ Content-Type: application/json
 {
   "tripRecordImages": [
     {
-      "imageUrl": "이미지링크1",
+      "imageUrl": "https://www.gangnam.go.kr/upload/editor/2022/10/07/af149235-ff84-420d-af5c-e652161de152.jpg",
       "tagType": "FOOD_TOURISM_LOCATION",
-      "tagUrl": "태그주소1"
+      "tagUrl": "https://www.siksinhot.com/P/56310"
     },
     {
-      "imageUrl": "이미지링크2",
+      "imageUrl": "https://www.gangnam.go.kr/upload/editor/2020/12/29/b03f9390-fed9-41fc-874c-81f4d6b200f8.jpg",
       "tagType": "AIRLINE_TICKET_PURCHASE",
-      "tagUrl": "태그주소2"
+      "tagUrl": "https://www.skyscanner.co.kr/?&utm_source=google&utm_medium=cpc&utm_campaign=KR-Flights-Search-KO-Generics&utm_term=%ED%95%AD%EA%B3%B5%EA%B6%8C%EC%98%88%EC%95%BD&associateID=SEM_GGF_19370_00080&gclsrc=ds2"
     }
   ],
-  "title": "피드 제목",
-  "content": "여행의 전반적인 후기나 메모",
+  "title": "재밌는 강남 -> 일본 여행",
+  "content": "재밌게 강남을 다녀왔습니다. 강남역에서 맛있는 음식을 먹고, 쇼핑도 하고, 즐거운 시간을 보냈습니다. 도쿄 디즈니 랜드도 다녀왔어요",
   "expenseRangeType": "BELOW_50",
   "hashTags": [
     "연인끼리",
@@ -25,41 +25,67 @@ Content-Type: application/json
   ],
   "countries": "한국,일본",
   "tripStartDay": "2024-01-10",
-  "tripEndDay": "2024-01-20",
+  "tripEndDay": "2024-01-12",
   "tripRecordSchedules": [
     {
       "dayNumber": 1,
       "orderNumber": 1,
-      "placeId": 2,
-      "content": "방문한 장소에 대한 메모나 정보",
+      "placeId": 6,
+      "content": "1일차 첫번째 방문 장소 강남",
       "tripRecordScheduleImages": [
-        "스케줄 이미지 링크1",
-        "스케줄 이미지 링크2"
+        "https://www.gangnam.go.kr/upload/editor/2022/10/07/af149235-ff84-420d-af5c-e652161de152.jpg",
+        "https://www.gangnam.go.kr/upload/editor/2022/10/07/af149235-ff84-420d-af5c-e652161de152.jpg"
       ],
       "tripRecordScheduleVideos": [
-        "스케줄 비디오 링크1",
-        "스케줄 비디오 링크2",
-        "스케줄 비디오 링크3"
+        "https://www.youtube.com/shorts/EjwHIfhr-uE",
+        "https://www.youtube.com/shorts/EjwHIfhr-uE"
       ],
       "tagType": "AIRLINE_TICKET_PURCHASE",
-      "tagUrl": "스케줄 태그 링크1"
+      "tagUrl": "https://www.skyscanner.co.kr/?&utm_source=google&utm_medium=cpc&utm_campaign=KR-Flights-Search-KO-Generics&utm_term=%ED%95%AD%EA%B3%B5%EA%B6%8C%EC%98%88%EC%95%BD&associateID=SEM_GGF_19370_00080&gclsrc=ds2"
     },
     {
       "dayNumber": 1,
       "orderNumber": 2,
-      "placeId": 2,
-      "content": "내용",
+      "placeId": 6,
+      "content": "1일차 두번째 방문장소 강남 맛집",
       "tripRecordScheduleImages": [
-        "스케줄 이미지 링크3",
-        "스케줄 이미지 링크4"
       ],
       "tripRecordScheduleVideos": [
-        "스케줄 비디오 링크4",
-        "스케줄 비디오 링크5",
-        "스케줄 비디오 링크6"
+      ]
+    },
+    {
+      "dayNumber": 2,
+      "orderNumber": 1,
+      "placeId": 7,
+      "content": "2번째 날 첫째 도쿄 디즈니 랜드 방문",
+      "tripRecordScheduleImages": [
+        "https://www.gangnam.go.kr/upload/editor/2022/10/07/af149235-ff84-420d-af5c-e652161de152.jpg",
+        "https://www.gangnam.go.kr/upload/editor/2022/10/07/af149235-ff84-420d-af5c-e652161de152.jpg"
+      ],
+      "tripRecordScheduleVideos": [
+        "https://www.youtube.com/shorts/EjwHIfhr-uE",
+        "https://www.youtube.com/shorts/EjwHIfhr-uE",
+        "https://www.youtube.com/shorts/EjwHIfhr-uE"
       ],
       "tagType": "AIRLINE_TICKET_PURCHASE",
-      "tagUrl": "스케줄 태그 링크2"
+      "tagUrl": "https://www.skyscanner.co.kr/?&utm_source=google&utm_medium=cpc&utm_campaign=KR-Flights-Search-KO-Generics&utm_term=%ED%95%AD%EA%B3%B5%EA%B6%8C%EC%98%88%EC%95%BD&associateID=SEM_GGF_19370_00080&gclsrc=ds2"
+    },
+    {
+      "dayNumber": 2,
+      "orderNumber": 2,
+      "placeId": 7,
+      "content": "2번째 날 둘째 도쿄 디즈니 랜드 방문",
+      "tripRecordScheduleImages": [
+        "https://www.gangnam.go.kr/upload/editor/2022/10/07/af149235-ff84-420d-af5c-e652161de152.jpg",
+        "https://www.gangnam.go.kr/upload/editor/2022/10/07/af149235-ff84-420d-af5c-e652161de152.jpg"
+      ],
+      "tripRecordScheduleVideos": [
+        "https://www.youtube.com/shorts/EjwHIfhr-uE",
+        "https://www.youtube.com/shorts/EjwHIfhr-uE",
+        "https://www.youtube.com/shorts/EjwHIfhr-uE"
+      ],
+      "tagType": "AIRLINE_TICKET_PURCHASE",
+      "tagUrl": "https://www.skyscanner.co.kr/?&utm_source=google&utm_medium=cpc&utm_campaign=KR-Flights-Search-KO-Generics&utm_term=%ED%95%AD%EA%B3%B5%EA%B6%8C%EC%98%88%EC%95%BD&associateID=SEM_GGF_19370_00080&gclsrc=ds2"
     }
   ]
 }


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)


- **간략한 설명**:
- 여행 계획 수정 및 삭제 api를 추가하였습니다.
- 여행 후기 수정 및 삭제 api를 추가하였습니다.
- 여행 후기를 나의 여행 계획으로 복사해 오는 api를 추가하였습니다.
- 여행계획을 tripPlanId로 상세조회 하는 api를 추가 하였습니다.
- 불필요한 연관관계를 삭제하였습니다.

---

## 🛠 작성/변경 사항

- TripRecord 수정 api 추가 

- TripRecordSchedule에 member 연관관계 삭제 

- TripPlan 삭제 코드 추가 

- TripPlan 수정 api 추가 

- TripPlanSchedule에 member 연관관계 삭제 

- 여행 계획 작성시 장소에 대한 검증 로직 추가 

- 여행 후기 작성시 장소에 대한 검증 로직 추가 

- 여행 후기를 복사해서 여행 계획 생성하는 api 추가 

- tripRecord와 tripRecordStore 연관관계 추가
---

## 🔗 관련 이슈

- **이슈 링크1** : #54
