### PR TITLE
[feat] 홈 메인 피드 API 1차 구현

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityContentReadController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityContentReadController.java
@@ -3,6 +3,7 @@ package com.haejwo.tripcometrue.domain.city.controller;
 import com.haejwo.tripcometrue.domain.city.dto.response.*;
 import com.haejwo.tripcometrue.domain.city.service.CityContentReadService;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import com.haejwo.tripcometrue.global.validator.annotation.HomeTopListQueryType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,6 +20,20 @@ import java.util.List;
 public class CityContentReadController {
 
     private final CityContentReadService cityContentReadService;
+
+    // 홈피드 TOP 인기 도시 리스트 조회
+    @GetMapping("/top-list")
+    public ResponseEntity<ResponseDTO<List<TopCityResponseDto>>> getTopCityList(
+        @RequestParam @HomeTopListQueryType String type
+    ) {
+        return ResponseEntity
+            .ok()
+            .body(
+                ResponseDTO.okWithData(
+                    cityContentReadService.getTopCityList(type)
+                )
+            );
+    }
 
     // 도시 관련 여행 후기 조회
     @GetMapping("/{cityId}/trip-records")

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/TopCityResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/TopCityResponseDto.java
@@ -1,0 +1,25 @@
+package com.haejwo.tripcometrue.domain.city.dto.response;
+
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import lombok.Builder;
+
+public record TopCityResponseDto(
+    Long cityId,
+    String cityName,
+    Integer storedCount,
+    String imageUrl
+) {
+
+    @Builder
+    public TopCityResponseDto {
+    }
+
+    public static TopCityResponseDto fromEntity(City entity) {
+        return TopCityResponseDto.builder()
+            .cityId(entity.getId())
+            .cityName(entity.getName())
+            .storedCount(entity.getStoreCount())
+            .imageUrl(entity.getImageUrl())
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
@@ -25,6 +25,8 @@ public class City extends BaseTimeEntity {
     private CurrencyUnit currency;
     private String weatherRecommendation;
     private String weatherDescription;
+    private Integer storeCount;
+    private String imageUrl;
 
     @Enumerated(EnumType.STRING)
     private Country country;
@@ -33,7 +35,7 @@ public class City extends BaseTimeEntity {
     private City(
         Long id, String name, String language, String timeDifference,
         String voltage, String visa, CurrencyUnit currency, String weatherRecommendation,
-        String weatherDescription, Country country
+        String weatherDescription, Integer storeCount, Country country, String imageUrl
     ) {
         this.id = id;
         this.name = name;
@@ -44,7 +46,14 @@ public class City extends BaseTimeEntity {
         this.currency = currency;
         this.weatherRecommendation = weatherRecommendation;
         this.weatherDescription = weatherDescription;
+        this.storeCount = storeCount;
         this.country = country;
+        this.imageUrl = imageUrl;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.storeCount = 0;
     }
 }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepository.java
@@ -2,10 +2,12 @@ package com.haejwo.tripcometrue.domain.city.repository;
 
 import com.haejwo.tripcometrue.domain.city.entity.City;
 import com.haejwo.tripcometrue.global.enums.Country;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CityRepository extends JpaRepository<City, Long> {
+import java.util.Optional;
+
+public interface CityRepository
+    extends JpaRepository<City, Long>, CityRepositoryCustom {
 
     Optional<City> findByNameAndCountry(String name, Country country);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.haejwo.tripcometrue.domain.city.repository;
+
+import com.haejwo.tripcometrue.domain.city.entity.City;
+
+import java.util.List;
+
+public interface CityRepositoryCustom {
+
+    List<City> findTopCityListDomestic(int size);
+
+    List<City> findTopCityListOverseas(int size);
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.haejwo.tripcometrue.domain.city.repository;
+
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.global.enums.Country;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.haejwo.tripcometrue.domain.city.entity.QCity.city;
+
+@RequiredArgsConstructor
+public class CityRepositoryImpl implements CityRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<City> findTopCityListDomestic(int size) {
+        return queryFactory
+            .selectFrom(city)
+            .where(city.country.eq(Country.KOREA))
+            .orderBy(city.storeCount.desc())
+            .limit(size)
+            .fetch();
+    }
+
+    @Override
+    public List<City> findTopCityListOverseas(int size) {
+        return queryFactory
+            .selectFrom(city)
+            .where(city.country.eq(Country.KOREA).not())
+            .orderBy(city.storeCount.desc())
+            .limit(size)
+            .fetch();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityContentReadService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityContentReadService.java
@@ -30,6 +30,24 @@ public class CityContentReadService {
 
     private static final int CITY_HOT_PLACES_SIZE = 10;
     private static final int CITY_MEDIA_CONTENT_SIZE = 10;
+    private static final int HOME_CONTENT_SIZE = 5;
+
+    // 홈피드 인기 도시 리스트 조회
+    public List<TopCityResponseDto> getTopCityList(String type) {
+        if (type.equalsIgnoreCase("domestic")) {
+            return cityRepository
+                .findTopCityListDomestic(HOME_CONTENT_SIZE)
+                .stream()
+                .map(TopCityResponseDto::fromEntity)
+                .toList();
+        } else {
+            return cityRepository
+                .findTopCityListOverseas(HOME_CONTENT_SIZE)
+                .stream()
+                .map(TopCityResponseDto::fromEntity)
+                .toList();
+        }
+    }
 
     // 도시 핫플레이스 리스트 조회
     @Transactional(readOnly = true)

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
@@ -1,9 +1,9 @@
 package com.haejwo.tripcometrue.domain.triprecord.controller;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.ModelAttribute.TripRecordListRequestAttribute;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TopTripRecordResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.service.TripRecordService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
@@ -2,10 +2,12 @@ package com.haejwo.tripcometrue.domain.triprecord.controller;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.ModelAttribute.TripRecordListRequestAttribute;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.TripRecordListResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TopTripRecordResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.service.TripRecordService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import com.haejwo.tripcometrue.global.validator.annotation.HomeTopListQueryType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -53,6 +55,19 @@ public class TripRecordController {
                     .status(responseBody.getCode())
                     .body(responseBody);
 
+    }
+
+    @GetMapping("/top-list")
+    public ResponseEntity<ResponseDTO<List<TopTripRecordResponseDto>>> tripRecordTopList(
+        @RequestParam("type") @HomeTopListQueryType String type
+    ) {
+        return ResponseEntity
+            .ok()
+            .body(
+                ResponseDTO.okWithData(
+                    tripRecordService.findTopTripRecordList(type)
+                )
+            );
     }
 
     @GetMapping("/my")

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
@@ -1,22 +1,19 @@
 package com.haejwo.tripcometrue.domain.triprecord.controller;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.ModelAttribute.TripRecordListRequestAttribute;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.service.TripRecordService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/trip-records")
@@ -24,7 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class TripRecordController {
 
     private final TripRecordService tripRecordService;
-
 
     @GetMapping("/{tripRecordId}")
     public ResponseEntity<ResponseDTO<TripRecordDetailResponseDto>> tripRecordDetail(

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordScheduleVideoController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordScheduleVideoController.java
@@ -1,0 +1,32 @@
+package com.haejwo.tripcometrue.domain.triprecord.controller;
+
+import com.haejwo.tripcometrue.domain.triprecord.service.TripRecordScheduleVideoService;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import com.haejwo.tripcometrue.global.validator.annotation.HomeVideoListQueryType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/schedule-videos")
+@RestController
+public class TripRecordScheduleVideoController {
+
+    private final TripRecordScheduleVideoService tripRecordScheduleVideoService;
+
+    @GetMapping("/list")
+    public ResponseEntity<ResponseDTO<?>> getVideosByType(
+        @RequestParam("type") @HomeVideoListQueryType String type
+    ) {
+        return ResponseEntity
+            .ok()
+            .body(
+                ResponseDTO.okWithData(
+                    tripRecordScheduleVideoService.getNewestVideos(type)
+                )
+            );
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/query/NewestTripRecordScheduleVideoQueryDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/query/NewestTripRecordScheduleVideoQueryDto.java
@@ -1,0 +1,14 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.query;
+
+
+public record NewestTripRecordScheduleVideoQueryDto(
+    Long id,
+    Long tripRecordId,
+    String tripRecordTitle,
+    String videoUrl,
+    String thumbnailUrl,
+    Integer storeCount,
+    Long memberId,
+    String memberName
+) {
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TopTripRecordResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TopTripRecordResponseDto.java
@@ -1,0 +1,56 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord;
+
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordImage;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordSchedule;
+import lombok.Builder;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public record TopTripRecordResponseDto(
+    Long tripRecordId,
+    String tripRecordTitle,
+    Long memberId,
+    String memberName,
+    String profileImageUrl,
+    Set<String> cityNames,
+    Integer totalDays,
+    Integer storedCount,
+    String imageUrl
+) {
+
+    @Builder
+    public TopTripRecordResponseDto {
+    }
+
+    public static TopTripRecordResponseDto fromEntity(TripRecord entity) {
+        Set<String> cityNames = new HashSet<>();
+        for (TripRecordSchedule tripRecordSchedule : entity.getTripRecordSchedules()) {
+            cityNames.add(tripRecordSchedule.getPlace().getCity().getName());
+        }
+
+        Member member = entity.getMember();
+
+        return TopTripRecordResponseDto.builder()
+            .tripRecordId(entity.getId())
+            .tripRecordTitle(entity.getTitle())
+            .memberId(member.getId())
+            .memberName(member.getMemberBase().getNickname())
+            .profileImageUrl(member.getProfile_image())
+            .cityNames(cityNames)
+            .totalDays(entity.getTotalDays())
+            .storedCount(entity.getStoreCount())
+            .imageUrl(
+                entity.getTripRecordImages()
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .map(TripRecordImage::getImageUrl)
+                    .orElse(null)
+            )
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule_media/NewestTripRecordScheduleVideoResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule_media/NewestTripRecordScheduleVideoResponseDto.java
@@ -1,0 +1,33 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media;
+
+import com.haejwo.tripcometrue.domain.triprecord.dto.query.NewestTripRecordScheduleVideoQueryDto;
+import lombok.Builder;
+
+public record NewestTripRecordScheduleVideoResponseDto(
+    Long id,
+    Long tripRecordId,
+    String tripRecordTitle,
+    String videoUrl,
+    String thumbnailUrl,
+    Integer storeCount,
+    Long memberId,
+    String memberName
+) {
+
+    @Builder
+    public NewestTripRecordScheduleVideoResponseDto {
+    }
+
+    public static NewestTripRecordScheduleVideoResponseDto fromQueryDto(NewestTripRecordScheduleVideoQueryDto queryDto) {
+        return NewestTripRecordScheduleVideoResponseDto.builder()
+            .id(queryDto.id())
+            .tripRecordId(queryDto.tripRecordId())
+            .tripRecordTitle(queryDto.tripRecordTitle())
+            .videoUrl(queryDto.videoUrl())
+            .thumbnailUrl(queryDto.thumbnailUrl())
+            .storeCount(queryDto.storeCount())
+            .memberId(queryDto.memberId())
+            .memberName(queryDto.memberName())
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordScheduleVideo.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecordScheduleVideo.java
@@ -25,15 +25,17 @@ public class TripRecordScheduleVideo extends BaseTimeEntity {
     private Long id;
 
     private String videoUrl;
+    private String thumbnailUrl;
 
     @ManyToOne
     @JoinColumn(name = "trip_schedule_id")
     private TripRecordSchedule tripRecordSchedule;
 
     @Builder
-    public TripRecordScheduleVideo(String videoUrl,
+    public TripRecordScheduleVideo(String videoUrl, String thumbnailUrl,
         TripRecordSchedule tripRecordSchedule) {
         this.videoUrl = videoUrl;
+        this.thumbnailUrl = thumbnailUrl;
         this.tripRecordSchedule = tripRecordSchedule;
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepository.java
@@ -7,6 +7,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface TripRecordCustomRepository {
 
-    List<TripRecord> finTripRecordWithFilter(Pageable pageable, TripRecordListRequestAttribute request);
-
+    List<TripRecord> findTripRecordWithFilter(Pageable pageable, TripRecordListRequestAttribute request);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepository.java
@@ -8,4 +8,8 @@ import org.springframework.data.domain.Pageable;
 public interface TripRecordCustomRepository {
 
     List<TripRecord> findTripRecordWithFilter(Pageable pageable, TripRecordListRequestAttribute request);
+
+    List<TripRecord> findTopTripRecordListDomestic(int size);
+
+    List<TripRecord> findTopTripRecordListOverseas(int size);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
@@ -6,15 +6,21 @@ import com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordSchedule;
 import com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordTag;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExpenseRangeType;
+import com.haejwo.tripcometrue.global.enums.Country;
 import com.querydsl.core.BooleanBuilder;
 import java.util.List;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
 public class TripRecordCustomRepositoryImpl extends QuerydslRepositorySupport implements TripRecordCustomRepository {
 
-    public TripRecordCustomRepositoryImpl() {
+    private final JPAQueryFactory queryFactory;
+
+    public TripRecordCustomRepositoryImpl(JPAQueryFactory queryFactory) {
         super(TripRecord.class);
+        this.queryFactory = queryFactory;
     }
 
     @Override
@@ -56,5 +62,29 @@ public class TripRecordCustomRepositoryImpl extends QuerydslRepositorySupport im
             .fetch();
 
         return result;
+    }
+
+    @Override
+    public List<TripRecord> findTopTripRecordListDomestic(int size) {
+        QTripRecord tripRecord = QTripRecord.tripRecord;
+
+        return queryFactory
+            .selectFrom(tripRecord)
+            .where(tripRecord.countries.containsIgnoreCase(Country.KOREA.name()))
+            .orderBy(tripRecord.averageRating.desc(), tripRecord.storeCount.desc())
+            .limit(size)
+            .fetch();
+    }
+
+    @Override
+    public List<TripRecord> findTopTripRecordListOverseas(int size) {
+        QTripRecord tripRecord = QTripRecord.tripRecord;
+
+        return queryFactory
+            .selectFrom(tripRecord)
+            .where(tripRecord.countries.containsIgnoreCase(Country.KOREA.name()).not())
+            .orderBy(tripRecord.averageRating.desc(), tripRecord.storeCount.desc())
+            .limit(size)
+            .fetch();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
@@ -18,7 +18,7 @@ public class TripRecordCustomRepositoryImpl extends QuerydslRepositorySupport im
     }
 
     @Override
-    public List<TripRecord> finTripRecordWithFilter(
+    public List<TripRecord> findTripRecordWithFilter(
         Pageable pageable,
         TripRecordListRequestAttribute request
     ) {

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_video;
 
+import com.haejwo.tripcometrue.domain.triprecord.dto.query.NewestTripRecordScheduleVideoQueryDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordScheduleVideo;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -11,4 +12,10 @@ public interface TripRecordScheduleVideoRepositoryCustom {
     Slice<TripRecordScheduleVideo> findByCityId(Long cityId, Pageable pageable);
 
     List<TripRecordScheduleVideo> findByCityIdOrderByCreatedAtDescLimitSize(Long cityId, Integer size);
+
+    List<NewestTripRecordScheduleVideoQueryDto> findNewestVideoList(int size);
+
+    List<NewestTripRecordScheduleVideoQueryDto> findNewestVideoListDomestic(int size);
+
+    List<NewestTripRecordScheduleVideoQueryDto> findNewestVideoListOverseas(int size);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_video;
 
+import com.haejwo.tripcometrue.domain.triprecord.dto.query.NewestTripRecordScheduleVideoQueryDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordScheduleVideo;
+import com.haejwo.tripcometrue.global.enums.Country;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +16,9 @@ import org.springframework.data.domain.Sort;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.haejwo.tripcometrue.domain.member.entity.QMember.member;
 import static com.haejwo.tripcometrue.domain.place.entity.QPlace.place;
+import static com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecord.tripRecord;
 import static com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordSchedule.tripRecordSchedule;
 import static com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordScheduleVideo.tripRecordScheduleVideo;
 
@@ -55,6 +60,83 @@ public class TripRecordScheduleVideoRepositoryImpl implements TripRecordSchedule
             .where(
                 place.city.id.eq(cityId)
             )
+            .orderBy(tripRecordScheduleVideo.createdAt.desc())
+            .limit(size)
+            .fetch();
+    }
+
+    @Override
+    public List<NewestTripRecordScheduleVideoQueryDto> findNewestVideoList(int size) {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    NewestTripRecordScheduleVideoQueryDto.class,
+                    tripRecordScheduleVideo.id,
+                    tripRecord.id,
+                    tripRecord.title,
+                    tripRecordScheduleVideo.videoUrl,
+                    tripRecordScheduleVideo.thumbnailUrl,
+                    tripRecord.storeCount,
+                    member.id,
+                    member.memberBase.nickname
+                )
+            )
+            .from(tripRecordScheduleVideo)
+            .join(tripRecordScheduleVideo.tripRecordSchedule, tripRecordSchedule)
+            .join(tripRecordSchedule.tripRecord, tripRecord)
+            .join(tripRecord.member, member)
+            .orderBy(tripRecordScheduleVideo.createdAt.desc())
+            .limit(size)
+            .fetch();
+    }
+
+    @Override
+    public List<NewestTripRecordScheduleVideoQueryDto> findNewestVideoListDomestic(int size) {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    NewestTripRecordScheduleVideoQueryDto.class,
+                    tripRecordScheduleVideo.id,
+                    tripRecord.id,
+                    tripRecord.title,
+                    tripRecordScheduleVideo.videoUrl,
+                    tripRecordScheduleVideo.thumbnailUrl,
+                    tripRecord.storeCount,
+                    member.id,
+                    member.memberBase.nickname
+                )
+            )
+            .from(tripRecordScheduleVideo)
+            .join(tripRecordScheduleVideo.tripRecordSchedule, tripRecordSchedule)
+            .join(tripRecordSchedule.tripRecord, tripRecord)
+            .join(tripRecord.member, member)
+            .where(tripRecord.countries.containsIgnoreCase(Country.KOREA.name()))
+            .orderBy(tripRecordScheduleVideo.createdAt.desc())
+            .limit(size)
+            .fetch();
+    }
+
+    @Override
+    public List<NewestTripRecordScheduleVideoQueryDto> findNewestVideoListOverseas(int size) {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    NewestTripRecordScheduleVideoQueryDto.class,
+                    tripRecordScheduleVideo.id,
+                    tripRecord.id,
+                    tripRecord.title,
+                    tripRecordScheduleVideo.videoUrl,
+                    tripRecordScheduleVideo.thumbnailUrl,
+                    tripRecord.storeCount,
+                    member.id,
+                    member.memberBase.nickname
+                )
+            )
+            .from(tripRecordScheduleVideo)
+            .join(tripRecordScheduleVideo.tripRecordSchedule, tripRecordSchedule)
+            .join(tripRecordSchedule.tripRecord, tripRecord)
+            .join(tripRecord.member, member)
+            .where(tripRecord.countries.containsIgnoreCase(Country.KOREA.name()).not())
             .orderBy(tripRecordScheduleVideo.createdAt.desc())
             .limit(size)
             .fetch();

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordScheduleVideoService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordScheduleVideoService.java
@@ -1,0 +1,34 @@
+package com.haejwo.tripcometrue.domain.triprecord.service;
+
+import com.haejwo.tripcometrue.domain.triprecord.dto.query.NewestTripRecordScheduleVideoQueryDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media.NewestTripRecordScheduleVideoResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_video.TripRecordScheduleVideoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class TripRecordScheduleVideoService {
+
+    private final TripRecordScheduleVideoRepository tripRecordScheduleVideoRepository;
+
+    private static final int HOME_CONTENT_SIZE = 5;
+
+    public List<NewestTripRecordScheduleVideoResponseDto> getNewestVideos(String type) {
+        List<NewestTripRecordScheduleVideoQueryDto> queryResults = new ArrayList<>();
+        if (type.equalsIgnoreCase("all")) {
+            queryResults = tripRecordScheduleVideoRepository.findNewestVideoList(HOME_CONTENT_SIZE);
+        } else if (type.equalsIgnoreCase("domestic")) {
+            queryResults = tripRecordScheduleVideoRepository.findNewestVideoListDomestic(HOME_CONTENT_SIZE);
+        } else {
+            queryResults = tripRecordScheduleVideoRepository.findNewestVideoListOverseas(HOME_CONTENT_SIZE);
+        }
+
+        return queryResults.stream()
+            .map(NewestTripRecordScheduleVideoResponseDto::fromQueryDto)
+            .toList();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -1,8 +1,8 @@
 package com.haejwo.tripcometrue.domain.triprecord.service;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.ModelAttribute.TripRecordListRequestAttribute;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewCount;
 import com.haejwo.tripcometrue.domain.triprecord.exception.TripRecordNotFoundException;
@@ -10,14 +10,15 @@ import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord.TripRecor
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_viewcount.TripRecordViewCountRepository;
 import com.haejwo.tripcometrue.domain.triprecordViewHistory.service.TripRecordViewHistoryService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +28,6 @@ public class TripRecordService {
     private final TripRecordRepository tripRecordRepository;
     private final TripRecordViewCountRepository tripRecordViewCountRepository;
     private final TripRecordViewHistoryService tripRecordViewHistoryService;
-
 
     @Transactional
     public TripRecordDetailResponseDto findTripRecord(PrincipalDetails principalDetails, Long tripRecordId) {
@@ -58,7 +58,6 @@ public class TripRecordService {
         return responseDtos;
     }
 
-
     @Transactional
     public void incrementViewCount(TripRecord tripRecord) {
 
@@ -72,23 +71,6 @@ public class TripRecordService {
 
     }
 
-    private TripRecordViewCount createNewViewCount(TripRecord tripRecord, LocalDate today) {
-        return TripRecordViewCount.builder()
-            .date(today)
-            .tripRecord(tripRecord)
-            .viewCount(0)
-            .build();
-    }
-
-
-
-    private TripRecord findTripRecordById(Long tripRecordId) {
-        TripRecord findTripRecord = tripRecordRepository.findById(tripRecordId)
-            .orElseThrow(TripRecordNotFoundException::new);
-        return findTripRecord;
-    }
-
-
     @Transactional(readOnly = true)
     public List<TripRecordListResponseDto> getMyTripRecordsList(
         PrincipalDetails principalDetails, Pageable pageable) {
@@ -98,6 +80,20 @@ public class TripRecordService {
         return tripRecords.stream()
             .map(TripRecordListResponseDto::fromEntity)
             .collect(Collectors.toList());
+    }
+
+    private TripRecordViewCount createNewViewCount(TripRecord tripRecord, LocalDate today) {
+        return TripRecordViewCount.builder()
+            .date(today)
+            .tripRecord(tripRecord)
+            .viewCount(0)
+            .build();
+    }
+
+    private TripRecord findTripRecordById(Long tripRecordId) {
+        TripRecord findTripRecord = tripRecordRepository.findById(tripRecordId)
+            .orElseThrow(TripRecordNotFoundException::new);
+        return findTripRecord;
     }
 
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -1,9 +1,9 @@
 package com.haejwo.tripcometrue.domain.triprecord.service;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.ModelAttribute.TripRecordListRequestAttribute;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TopTripRecordResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewCount;
 import com.haejwo.tripcometrue.domain.triprecord.exception.TripRecordNotFoundException;
@@ -29,6 +29,7 @@ public class TripRecordService {
     private final TripRecordRepository tripRecordRepository;
     private final TripRecordViewCountRepository tripRecordViewCountRepository;
     private final TripRecordViewHistoryService tripRecordViewHistoryService;
+
     private static final int HOME_CONTENT_SIZE = 5;
 
     @Transactional

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -2,6 +2,7 @@ package com.haejwo.tripcometrue.domain.triprecord.service;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.ModelAttribute.TripRecordListRequestAttribute;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.TripRecordListResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TopTripRecordResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordViewCount;
@@ -28,6 +29,7 @@ public class TripRecordService {
     private final TripRecordRepository tripRecordRepository;
     private final TripRecordViewCountRepository tripRecordViewCountRepository;
     private final TripRecordViewHistoryService tripRecordViewHistoryService;
+    private static final int HOME_CONTENT_SIZE = 5;
 
     @Transactional
     public TripRecordDetailResponseDto findTripRecord(PrincipalDetails principalDetails, Long tripRecordId) {
@@ -49,13 +51,30 @@ public class TripRecordService {
         Pageable pageable, TripRecordListRequestAttribute request
     ) {
 
-        List<TripRecord> result = tripRecordRepository.finTripRecordWithFilter(pageable, request);
+        List<TripRecord> result = tripRecordRepository.findTripRecordWithFilter(pageable, request);
 
         List<TripRecordListResponseDto> responseDtos = result.stream()
                                     .map(TripRecordListResponseDto::fromEntity)
                                     .toList();
 
         return responseDtos;
+    }
+
+    @Transactional(readOnly = true)
+    public List<TopTripRecordResponseDto> findTopTripRecordList(String type) {
+        if (type.equalsIgnoreCase("domestic")) {
+            return tripRecordRepository
+                .findTopTripRecordListDomestic(HOME_CONTENT_SIZE)
+                .stream()
+                .map(TopTripRecordResponseDto::fromEntity)
+                .toList();
+        } else {
+            return tripRecordRepository
+                .findTopTripRecordListOverseas(HOME_CONTENT_SIZE)
+                .stream()
+                .map(TopTripRecordResponseDto::fromEntity)
+                .toList();
+        }
     }
 
     @Transactional

--- a/src/main/java/com/haejwo/tripcometrue/global/validator/HomeTopListQueryTypeValidator.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/validator/HomeTopListQueryTypeValidator.java
@@ -1,0 +1,20 @@
+package com.haejwo.tripcometrue.global.validator;
+
+import com.haejwo.tripcometrue.global.validator.annotation.HomeTopListQueryType;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Objects;
+
+public class HomeTopListQueryTypeValidator implements ConstraintValidator<HomeTopListQueryType, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+
+        if (Objects.isNull(value)) {
+            return false;
+        }
+
+        return value.equalsIgnoreCase("overseas") || value.equalsIgnoreCase("domestic");
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/validator/HomeVideoListQueryTypeValidator.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/validator/HomeVideoListQueryTypeValidator.java
@@ -1,0 +1,21 @@
+package com.haejwo.tripcometrue.global.validator;
+
+import com.haejwo.tripcometrue.global.validator.annotation.HomeVideoListQueryType;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Objects;
+
+public class HomeVideoListQueryTypeValidator implements ConstraintValidator<HomeVideoListQueryType, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (Objects.isNull(value)) {
+            return false;
+        }
+
+        return value.equalsIgnoreCase("all")
+            || value.equalsIgnoreCase("domestic")
+            || value.equalsIgnoreCase("overseas");
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/validator/annotation/HomeTopListQueryType.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/validator/annotation/HomeTopListQueryType.java
@@ -1,0 +1,19 @@
+package com.haejwo.tripcometrue.global.validator.annotation;
+
+import com.haejwo.tripcometrue.global.validator.HomeTopListQueryTypeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = HomeTopListQueryTypeValidator.class)
+public @interface HomeTopListQueryType {
+    String message() default "올바른 검색 타입이 아닙니다. [overseas, domestic] 중 하나를 입력하세요.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/haejwo/tripcometrue/global/validator/annotation/HomeVideoListQueryType.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/validator/annotation/HomeVideoListQueryType.java
@@ -1,0 +1,19 @@
+package com.haejwo.tripcometrue.global.validator.annotation;
+
+import com.haejwo.tripcometrue.global.validator.HomeVideoListQueryTypeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = HomeVideoListQueryTypeValidator.class)
+public @interface HomeVideoListQueryType {
+    String message() default "올바른 검색 타입이 아닙니다. [all, overseas, domestic] 중 하나를 입력하세요.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_image/TripRecordScheduleImageRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_image/TripRecordScheduleImageRepositoryTest.java
@@ -18,6 +18,7 @@ import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord.TripRecor
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule.TripRecordScheduleRepository;
 import com.haejwo.tripcometrue.global.enums.Country;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -360,5 +361,15 @@ class TripRecordScheduleImageRepositoryTest {
 
         // then
         assertThat(result).hasSize(7);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        tripRecordScheduleImageRepository.deleteAll();
+        tripRecordScheduleRepository.deleteAll();
+        tripRecordRepository.deleteAll();
+        memberRepository.deleteAll();
+        placeRepository.deleteAll();
+        cityRepository.deleteAll();
     }
 }

--- a/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
@@ -1,0 +1,329 @@
+package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_video;
+
+import com.haejwo.tripcometrue.config.TestQuerydslConfig;
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.member.repository.MemberRepository;
+import com.haejwo.tripcometrue.domain.place.entity.Place;
+import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
+import com.haejwo.tripcometrue.domain.triprecord.dto.query.NewestTripRecordScheduleVideoQueryDto;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordSchedule;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordScheduleVideo;
+import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExpenseRangeType;
+import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExternalLinkTagType;
+import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord.TripRecordRepository;
+import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule.TripRecordScheduleRepository;
+import com.haejwo.tripcometrue.global.enums.Country;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Slf4j
+@Import(TestQuerydslConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class TripRecordScheduleVideoRepositoryTest {
+
+    @Autowired
+    private TripRecordScheduleVideoRepository tripRecordScheduleVideoRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CityRepository cityRepository;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private TripRecordRepository tripRecordRepository;
+
+    @Autowired
+    private TripRecordScheduleRepository tripRecordScheduleRepository;
+
+    private List<City> cities;
+    private List<Place> places;
+
+    @BeforeEach
+    void setUp() {
+
+        cities = new ArrayList<>();
+        cities.add(
+            cityRepository.save(
+                City.builder()
+                    .name("방콕")
+                    .language("태국어")
+                    .timeDifference("2시간 느림")
+                    .currency(CurrencyUnit.THB)
+                    .visa("visa")
+                    .weatherRecommendation("11~12월이 여행하기 가장 좋은 시기입니다.")
+                    .weatherDescription("방콕 날씨 설명")
+                    .voltage("220V")
+                    .country(Country.THAILAND)
+                    .build()
+            )
+        );
+
+        cities.add(
+            cityRepository.save(
+                City.builder()
+                    .name("부산")
+                    .language("한국어")
+                    .timeDifference("시차없음")
+                    .weatherRecommendation("11~12월이 여행하기 가장 좋은 시기입니다.")
+                    .weatherDescription("일본어 날씨 설명")
+                    .country(Country.KOREA)
+                    .build()
+            )
+        );
+
+        places = new ArrayList<>();
+
+        places.add(
+            placeRepository.save(
+                Place.builder()
+                    .name("여행지1")
+                    .address("여행지1 주소")
+                    .description("여행지 설명")
+                    .storedCount(100)
+                    .city(cities.get(0))
+                    .build()
+            )
+        );
+
+        places.add(
+            placeRepository.save(
+                Place.builder()
+                    .name("여행지2")
+                    .address("여행지2 주소")
+                    .description("여행지2 설명")
+                    .storedCount(150)
+                    .city(cities.get(0))
+                    .build()
+            )
+        );
+
+        places.add(
+            placeRepository.save(
+                Place.builder()
+                    .name("여행지3")
+                    .address("여행지3 주소")
+                    .description("여행지3 설명")
+                    .storedCount(115)
+                    .city(cities.get(1))
+                    .build()
+            )
+        );
+
+        places.add(
+            placeRepository.save(
+                Place.builder()
+                    .name("여행지4")
+                    .address("여행지4 주소")
+                    .description("여행지4 설명")
+                    .storedCount(200)
+                    .city(cities.get(1))
+                    .build()
+            )
+        );
+
+        TripRecord tripRecord1 = tripRecordRepository.save(
+            TripRecord.builder()
+                .averageRating(4)
+                .title("여행 후기 제목")
+                .content("여행 후기")
+                .countries("THAILAND")
+                .storeCount(100)
+                .expenseRangeType(ExpenseRangeType.ABOVE_300)
+                .member(memberRepository.save(
+                    Member.builder()
+                        .authority("ROLE_USER")
+                        .email("member@email.com")
+                        .password("password")
+                        .nickname("member")
+                        .build()
+                ))
+                .build()
+        );
+
+        TripRecord tripRecord2 = tripRecordRepository.save(
+            TripRecord.builder()
+                .averageRating(4)
+                .title("여행 후기 제목")
+                .content("여행 후기")
+                .countries("JAPAN")
+                .storeCount(200)
+                .expenseRangeType(ExpenseRangeType.BELOW_100)
+                .member(memberRepository.save(
+                    Member.builder()
+                        .authority("ROLE_USER")
+                        .email("member@email.com")
+                        .password("password")
+                        .nickname("member")
+                        .build()
+                ))
+                .build()
+        );
+
+        TripRecord tripRecord3 = tripRecordRepository.save(
+            TripRecord.builder()
+                .averageRating(4)
+                .title("여행 후기 제목")
+                .content("여행 후기")
+                .countries("KOREA")
+                .storeCount(150)
+                .expenseRangeType(ExpenseRangeType.BELOW_100)
+                .member(memberRepository.save(
+                    Member.builder()
+                        .authority("ROLE_USER")
+                        .email("member@email.com")
+                        .password("password")
+                        .nickname("member")
+                        .build()
+                ))
+                .build()
+        );
+
+        List<TripRecordSchedule> schedules = new ArrayList<>();
+
+        schedules.add(
+            tripRecordScheduleRepository.save(
+                TripRecordSchedule.builder()
+                    .tripRecord(tripRecord1)
+                    .place(places.get(0))
+                    .dayNumber(1)
+                    .ordering(1)
+                    .tagType(ExternalLinkTagType.ACCOMMODATION_RESERVATION)
+                    .tagUrl("tagUrl")
+                    .build()
+            )
+        );
+
+        schedules.add(
+            tripRecordScheduleRepository.save(
+                TripRecordSchedule.builder()
+                    .tripRecord(tripRecord1)
+                    .place(places.get(1))
+                    .dayNumber(1)
+                    .ordering(1)
+                    .tagType(ExternalLinkTagType.ACCOMMODATION_RESERVATION)
+                    .tagUrl("tagUrl")
+                    .build()
+            )
+        );
+
+        schedules.add(
+            tripRecordScheduleRepository.save(
+                TripRecordSchedule.builder()
+                    .tripRecord(tripRecord2)
+                    .place(places.get(2))
+                    .dayNumber(1)
+                    .ordering(1)
+                    .tagType(ExternalLinkTagType.ACCOMMODATION_RESERVATION)
+                    .tagUrl("tagUrl")
+                    .build()
+            )
+        );
+
+        schedules.add(
+            tripRecordScheduleRepository.save(
+                TripRecordSchedule.builder()
+                    .tripRecord(tripRecord2)
+                    .place(places.get(3))
+                    .dayNumber(1)
+                    .ordering(1)
+                    .tagType(ExternalLinkTagType.ACCOMMODATION_RESERVATION)
+                    .tagUrl("tagUrl")
+                    .build()
+            )
+        );
+
+        schedules.add(
+            tripRecordScheduleRepository.save(
+                TripRecordSchedule.builder()
+                    .tripRecord(tripRecord3)
+                    .place(places.get(0))
+                    .dayNumber(1)
+                    .ordering(1)
+                    .tagType(ExternalLinkTagType.ACCOMMODATION_RESERVATION)
+                    .tagUrl("tagUrl")
+                    .build()
+            )
+        );
+
+        schedules.add(
+            tripRecordScheduleRepository.save(
+                TripRecordSchedule.builder()
+                    .tripRecord(tripRecord3)
+                    .place(places.get(1))
+                    .dayNumber(1)
+                    .ordering(1)
+                    .tagType(ExternalLinkTagType.ACCOMMODATION_RESERVATION)
+                    .tagUrl("tagUrl")
+                    .build()
+            )
+        );
+
+        for (int i = 0; i < schedules.size(); i++) {
+            tripRecordScheduleVideoRepository.save(
+                TripRecordScheduleVideo.builder()
+                    .tripRecordSchedule(schedules.get(i))
+                    .thumbnailUrl("thumbnail" + i)
+                    .videoUrl("videoUrl" + i)
+                    .build()
+            );
+        }
+    }
+
+    @Test
+    void findNewestVideoList() {
+        //given
+        int size = 5;
+
+        //when
+        List<NewestTripRecordScheduleVideoQueryDto> result = tripRecordScheduleVideoRepository.findNewestVideoList(size);
+
+        //then
+        assertThat(result).hasSize(size);
+        assertThat(result.get(0).memberName()).isEqualTo("member");
+        assertThat(result.get(0).thumbnailUrl()).isEqualTo("thumbnail5");
+    }
+
+    @Test
+    void findNewestVideoListDomestic() {
+        //given
+        int size = 5;
+
+        //when
+        List<NewestTripRecordScheduleVideoQueryDto> result = tripRecordScheduleVideoRepository.findNewestVideoListDomestic(size);
+
+        //then
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void findNewestVideoListOverseas() {
+        //given
+        int size = 5;
+
+        //when
+        List<NewestTripRecordScheduleVideoQueryDto> result = tripRecordScheduleVideoRepository.findNewestVideoListOverseas(size);
+
+        //then
+        assertThat(result).hasSize(4);
+        assertThat(result.get(0).tripRecordId()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
@@ -325,7 +325,6 @@ class TripRecordScheduleVideoRepositoryTest {
 
         //then
         assertThat(result).hasSize(4);
-        assertThat(result.get(0).tripRecordId()).isEqualTo(2);
     }
 
     @AfterEach

--- a/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
@@ -18,6 +18,7 @@ import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord.TripRecor
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule.TripRecordScheduleRepository;
 import com.haejwo.tripcometrue.global.enums.Country;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -325,5 +326,15 @@ class TripRecordScheduleVideoRepositoryTest {
         //then
         assertThat(result).hasSize(4);
         assertThat(result.get(0).tripRecordId()).isEqualTo(2);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        tripRecordScheduleVideoRepository.deleteAll();
+        tripRecordScheduleRepository.deleteAll();
+        tripRecordRepository.deleteAll();
+        memberRepository.deleteAll();
+        placeRepository.deleteAll();
+        cityRepository.deleteAll();
     }
 }


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)

- **간략한 설명**:
  :  홈 메인 피드 API를 1차 구현 완료했습니다.
---

## 🛠 작성/변경 사항

- 홈 메인 최신 등록 쇼츠 리스트 조회 API
- 홈 메인 인기 도시 리스트 조회 API
- 홈 메인 인기 여행 후기 리스트 조회 API
- 홈 메인 크리에이터 리스트 조회 API : 미구현 -> 추후 구현 예정입니다!

- ### 🌟 변경사항
   - TripRecordScheduleVideo 엔티티에 'thumbnailUrl' 필드를 추가했습니다.
      - 쇼츠 리스트 GET 요청시 썸네일 url을 보내줘야 한다는 프론트 측의 요청에 따라 추가했습니다.
   - City 엔티티에 'storeCount', 'imageUrl' 필드 추가
      - 'storeCount' : 도시 보관수
      - 'imageUrl' : 도시 대표 이미지
     
---

## 🔗 관련 이슈

- **이슈 링크** : #80 

---

## 🧪 테스트

- **테스트 계획 및 결과** 
  - TripRecordScheduleVideoRepository에 구현한 전체/국내/해외 최신 등록 쇼츠 리스트 조회 테스트 코드를 작성했습니다.
     - 정상 동작 확인 완료했습니다.

This close #80 
