### PR TITLE
[feat] 계획,후기 작성시 국가-도시 조회 기능 추가

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepository.java
@@ -2,6 +2,7 @@ package com.haejwo.tripcometrue.domain.city.repository;
 
 import com.haejwo.tripcometrue.domain.city.entity.City;
 import com.haejwo.tripcometrue.global.enums.Country;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,4 +11,5 @@ public interface CityRepository
     extends JpaRepository<City, Long>, CityRepositoryCustom {
 
     Optional<City> findByNameAndCountry(String name, Country country);
+    List<City> findAllByCountry(Country country);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordEditController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordEditController.java
@@ -2,8 +2,10 @@ package com.haejwo.tripcometrue.domain.triprecord.controller;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.CreateSchedulePlaceRequestDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.TripRecordRequestDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.GetCountryResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule.SearchScheduleTripResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.service.TripRecordEditService;
+import com.haejwo.tripcometrue.global.enums.Continent;
 import com.haejwo.tripcometrue.global.enums.Country;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
@@ -89,6 +91,19 @@ public class TripRecordEditController {
         ResponseDTO<Long> responseBody
             = ResponseDTO.okWithData(
             tripRecordEditService.createSchedulePlace(createSchedulePlaceRequestDto));
+
+        return ResponseEntity
+            .status(responseBody.getCode())
+            .body(responseBody);
+    }
+
+    @GetMapping("/v1/country-city")
+    public ResponseEntity<ResponseDTO<List<GetCountryResponseDto>>> getCountryCity(
+        @RequestParam(required = false) Continent continent
+    ) {
+        ResponseDTO<List<GetCountryResponseDto>> responseBody
+            = ResponseDTO.okWithData(
+            tripRecordEditService.getCountryCity(continent));
 
         return ResponseEntity
             .status(responseBody.getCode())

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/GetCountryCityResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/GetCountryCityResponseDto.java
@@ -1,0 +1,27 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord;
+
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import lombok.Builder;
+
+public record GetCountryCityResponseDto(
+    Long cityId,
+    String cityName,
+    String cityImageUrl
+
+) {
+
+    @Builder
+    public GetCountryCityResponseDto(Long cityId, String cityName, String cityImageUrl) {
+        this.cityId = cityId;
+        this.cityName = cityName;
+        this.cityImageUrl = cityImageUrl;
+    }
+
+    public static GetCountryCityResponseDto fromEntity(City city) {
+        return GetCountryCityResponseDto.builder()
+            .cityId(city.getId())
+            .cityName(city.getName())
+            .cityImageUrl(city.getImageUrl())
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/GetCountryResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/GetCountryResponseDto.java
@@ -1,0 +1,15 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord;
+
+import com.haejwo.tripcometrue.global.enums.Continent;
+import com.haejwo.tripcometrue.global.enums.Country;
+import java.util.List;
+
+public record GetCountryResponseDto(
+    Continent continent,
+    Country country,
+    String countryName,
+    String countryImageUrl,
+    List<GetCountryCityResponseDto> cityList
+) {
+
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordEditService.java
@@ -9,6 +9,8 @@ import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.CreateSchedulePlaceRequestDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.TripRecordRequestDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.TripRecordScheduleRequestDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.GetCountryCityResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.GetCountryResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule.SearchScheduleTripResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordImage;
@@ -23,6 +25,7 @@ import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule.
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_image.TripRecordScheduleImageRepository;
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_video.TripRecordScheduleVideoRepository;
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_tag.TripRecordTagRepository;
+import com.haejwo.tripcometrue.global.enums.Continent;
 import com.haejwo.tripcometrue.global.enums.Country;
 import com.haejwo.tripcometrue.global.exception.PermissionDeniedException;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
@@ -180,5 +183,30 @@ public class TripRecordEditService {
             placeRepository.findById(tripRecordScheduleRequestDto.placeId())
                 .orElseThrow(PlaceNotFoundException::new);
         }
+    }
+
+    public List<GetCountryResponseDto> getCountryCity(Continent continent) {
+
+        List<GetCountryResponseDto> responseDtoList = new ArrayList<>();
+
+        for (Country country : Country.values()) {
+
+            if (continent == null || country.getContinent().equals(continent)) {
+                List<GetCountryCityResponseDto> cityList = new ArrayList<>();
+                cityRepository.findAllByCountry(country).forEach(city -> {
+                    cityList.add(GetCountryCityResponseDto.fromEntity(city));
+                });
+
+                responseDtoList.add(new GetCountryResponseDto(
+                    country.getContinent(),
+                    country,
+                    country.getDescription(),
+                    country.getImageUrl(),
+                    cityList
+                ));
+            }
+        }
+
+        return responseDtoList;
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/global/enums/Country.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/enums/Country.java
@@ -7,24 +7,39 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum Country {
 
-    KOREA("대한민국", Continent.KOREA),
-    JAPAN("일본", Continent.ASIA),
-    THAILAND("태국", Continent.ASIA),
-    INDONESIA("인도네시아", Continent.ASIA),
-    SINGAPORE("싱가포르", Continent.ASIA),
+    KOREA("대한민국", Continent.KOREA,
+        "https://a.cdn-hotels.com/gdcs/production74/d462/9fe21145-585c-4e7f-9373-24ed559ec010.jpg"),
+    JAPAN("일본", Continent.ASIA,
+        "https://www.state.gov/wp-content/uploads/2019/04/Japan-2107x1406.jpg"),
+    THAILAND("태국", Continent.ASIA,
+        "https://a.cdn-hotels.com/gdcs/production146/d585/aa60115c-bdfc-479f-88ba-5cb0f15a5af8.jpg?impolicy=fcrop&w=800&h=533&q=medium"),
+    INDONESIA("인도네시아", Continent.ASIA,
+        "https://media.timeout.com/images/105240189/750/422/image.jpg"),
+    SINGAPORE("싱가포르", Continent.ASIA,
+        "https://a.cdn-hotels.com/gdcs/production8/d1098/064a4e00-23ee-4137-8ec3-a0d27bca0782.jpg?impolicy=fcrop&w=800&h=533&q=medium"),
 
-    USA("미국", Continent.AMERICA),
-    CANADA("캐나다", Continent.AMERICA),
+    USA("미국", Continent.AMERICA,
+        "https://static.toiimg.com/photo/msid-84475066,width-96,height-65.cms"),
+    CANADA("캐나다", Continent.AMERICA,
+        "https://a.cdn-hotels.com/gdcs/production159/d204/01ae3fa0-c55c-11e8-9739-0242ac110006.jpg"),
 
-    FRANCE("프랑스", Continent.EUROPE),
-    UNITED_KINGDOM("영국", Continent.EUROPE),
-    ITALIA("이탈리아", Continent.EUROPE),
-    GERMANY("독일", Continent.EUROPE),
+    FRANCE("프랑스", Continent.EUROPE,
+        "https://www.state.gov/wp-content/uploads/2023/07/shutterstock_667548661v2.jpg"),
+    UNITED_KINGDOM("영국", Continent.EUROPE,
+        "https://www.worldatlas.com/r/w1200/upload/c7/28/32/untitled-design-207.jpg"),
+    ITALIA("이탈리아", Continent.EUROPE,
+        "https://tourismmedia.italia.it/is/image/mitur/3200x1800_mete_turistiche_hub_autunno-1?wid=1600&hei=900&fit=constrain,1&fmt=webp"),
+    GERMANY("독일", Continent.EUROPE,
+        "https://www.state.gov/wp-content/uploads/2018/11/Germany-2109x1406.jpg"),
 
-    GUAM("괌", Continent.OCEANIA),
-    NEW_ZEALAND("뉴질랜드", Continent.OCEANIA),
-    AUSTRALIA("호주", Continent.OCEANIA);
+    GUAM("괌", Continent.OCEANIA,
+        "https://a.cdn-hotels.com/gdcs/production49/d1519/6f89ae5d-542c-4fee-b333-a35761fe33d1.jpg"),
+    NEW_ZEALAND("뉴질랜드", Continent.OCEANIA,
+        "https://media.gq.com/photos/5ba1680236b2d004cdd843cd/16:9/w_2560%2Cc_limit/new-zealand-queenstown-travel-guide-gq.jpg"),
+    AUSTRALIA("호주", Continent.OCEANIA,
+        "https://i.natgeofe.com/k/b76526f3-bb84-489d-b229-56bcc08aa915/australia-sydney-opera-house.jpg?w=1084.125&h=611.625");
 
     private final String description;
     private final Continent continent;
+    private final String imageUrl;
 }

--- a/src/main/java/com/haejwo/tripcometrue/global/springsecurity/SpringSecurityConfig.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/springsecurity/SpringSecurityConfig.java
@@ -84,7 +84,8 @@ public class SpringSecurityConfig {
             .requestMatchers(new AntPathRequestMatcher("/v1/search-schedule-places/**")).permitAll()
             .requestMatchers(new AntPathRequestMatcher("/v1/schedule-place/**")).permitAll()
             .requestMatchers(new AntPathRequestMatcher("/v1/trip-plan/{planId}")).permitAll()
-
+            .requestMatchers(new AntPathRequestMatcher("/v1/country-city")).permitAll()
+            
             .anyRequest().authenticated());
 
         /**

--- a/src/test/http/trip_record/trip_record_edit.http
+++ b/src/test/http/trip_record/trip_record_edit.http
@@ -176,3 +176,16 @@ Content-Type: application/json
   "country": "KOREA",
   "cityname": "서울"
 }
+
+### 국가 조회
+GET http://localhost:8080/v1/country-city
+
+### 국가 조회
+GET http://localhost:8080/v1/country-city?continent=ASIA
+### 국가 조회
+GET http://localhost:8080/v1/country-city?continent=AMERICA
+### 국가 조회
+GET http://localhost:8080/v1/country-city?continent=EUROPE
+### 국가 조회
+GET http://localhost:8080/v1/country-city?continent=OCEANIA
+


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)

- **간략한 설명**:
  :  계획,후기 작성 시 DB에 있는 국가-도시를 조회할 수 있는 api를 추가하였습니다. 
![image](https://github.com/TripComeTrue/TripComeTrue_BE/assets/65541248/ba62ecb0-57f5-4ecb-acb6-1dca7b21eb17)
![image](https://github.com/TripComeTrue/TripComeTrue_BE/assets/65541248/43172979-28dd-47bb-affd-d5f76d75053e)


---

## 🛠 작성/변경 사항

- **(주요작성/변경사항)**
- 계획,후기 작성 시 DB에 있는 국가-도시를 조회할 수 있는 api를 추가
- country테이블을 따로 생성하지 않았으므로 country 대표이미지들을 country enum에서 관리하도록 추가
---

## 🔗 관련 이슈

- **이슈 링크1** : #85