### PR TITLE
[refactor] 여행지 리뷰(PlaceReview) 기능 추가 및 리팩토링

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/controller/PlaceReviewController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/controller/PlaceReviewController.java
@@ -6,7 +6,6 @@ import com.haejwo.tripcometrue.domain.review.placereview.dto.response.PlaceRevie
 import com.haejwo.tripcometrue.domain.review.placereview.dto.response.PlaceReviewResponseDto;
 import com.haejwo.tripcometrue.domain.review.placereview.dto.response.RegisterPlaceReviewResponseDto;
 import com.haejwo.tripcometrue.domain.review.placereview.dto.response.delete.DeletePlaceReviewResponseDto;
-import com.haejwo.tripcometrue.domain.review.placereview.dto.response.delete.DeleteSomeFailurePlaceReviewResponseDto;
 import com.haejwo.tripcometrue.domain.review.placereview.service.PlaceReviewService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.MULTI_STATUS;
 
 @Slf4j
 @RestController
@@ -88,30 +86,24 @@ public class PlaceReviewController {
             @RequestBody DeletePlaceReviewRequestDto requestDto
     ) {
 
-        DeletePlaceReviewResponseDto responseDto = placeReviewService.deletePlaceReviews(requestDto);
-
-        if (responseDto instanceof DeleteSomeFailurePlaceReviewResponseDto) {
-            return ResponseEntity
-                    .status(MULTI_STATUS)
-                    .body(ResponseDTO.errorWithData(MULTI_STATUS, responseDto));
-        }
-
+        DeletePlaceReviewResponseDto responseDto =
+                placeReviewService.deletePlaceReviews(requestDto);
         return ResponseEntity.ok(ResponseDTO.okWithData(responseDto));
     }
 
     @GetMapping("/reviews/my")
     public ResponseEntity<ResponseDTO<List<PlaceReviewListResponseDto>>> getMyPlaceReviews(
-        @AuthenticationPrincipal PrincipalDetails principalDetails,
-        Pageable pageable
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            Pageable pageable
     ) {
 
         List<PlaceReviewListResponseDto> responseDtos
-            = placeReviewService.getMyPlaceReviewsList(principalDetails, pageable);
+                = placeReviewService.getMyPlaceReviewsList(principalDetails, pageable);
         ResponseDTO<List<PlaceReviewListResponseDto>> responseBody
-            = ResponseDTO.okWithData(responseDtos);
+                = ResponseDTO.okWithData(responseDtos);
 
         return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(responseBody);
+                .status(HttpStatus.OK)
+                .body(responseBody);
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/controller/PlaceReviewController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/controller/PlaceReviewController.java
@@ -11,15 +11,11 @@ import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
@@ -56,18 +52,6 @@ public class PlaceReviewController {
         return ResponseEntity.ok(ResponseDTO.okWithData(responseDto));
     }
 
-    @GetMapping("/{placeId}/reviews")
-    public ResponseEntity<ResponseDTO<Page<PlaceReviewResponseDto>>> getPlaceReviewList(
-            @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @PathVariable Long placeId,
-            @RequestParam(defaultValue = "false") boolean onlyImage,
-            Pageable pageable
-    ) {
-
-        Page<PlaceReviewResponseDto> responseDtos = placeReviewService.getPlaceReviews(principalDetails, placeId, onlyImage, pageable);
-        return ResponseEntity.ok(ResponseDTO.okWithData(responseDtos));
-    }
-
     @PutMapping("/reviews/{placeReviewId}")
     public ResponseEntity<ResponseDTO<PlaceReviewResponseDto>> modifyPlaceReview(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
@@ -91,19 +75,27 @@ public class PlaceReviewController {
         return ResponseEntity.ok(ResponseDTO.okWithData(responseDto));
     }
 
+    @GetMapping("/{placeId}/reviews")
+    public ResponseEntity<ResponseDTO<PlaceReviewListResponseDto>> getPlaceReviewList(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable Long placeId,
+            @RequestParam(defaultValue = "false") boolean onlyImage,
+            Pageable pageable
+    ) {
+
+        PlaceReviewListResponseDto responseDtos =
+                placeReviewService.getPlaceReviewList(principalDetails, placeId, onlyImage, pageable);
+        return ResponseEntity.ok(ResponseDTO.okWithData(responseDtos));
+    }
+
     @GetMapping("/reviews/my")
-    public ResponseEntity<ResponseDTO<List<PlaceReviewListResponseDto>>> getMyPlaceReviews(
+    public ResponseEntity<ResponseDTO<PlaceReviewListResponseDto>> getMyPlaceReviews(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             Pageable pageable
     ) {
 
-        List<PlaceReviewListResponseDto> responseDtos
-                = placeReviewService.getMyPlaceReviewsList(principalDetails, pageable);
-        ResponseDTO<List<PlaceReviewListResponseDto>> responseBody
-                = ResponseDTO.okWithData(responseDtos);
-
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(responseBody);
+        PlaceReviewListResponseDto responseDtos
+                = placeReviewService.getMyPlaceReviewList(principalDetails, pageable);
+        return ResponseEntity.ok((ResponseDTO.okWithData(responseDtos)));
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/controller/PlaceReviewController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/controller/PlaceReviewController.java
@@ -74,7 +74,8 @@ public class PlaceReviewController {
     public ResponseEntity<ResponseDTO<PlaceReviewResponseDto>> modifyPlaceReview(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long placeReviewId,
-            @RequestBody @Validated PlaceReviewRequestDto requestDto) {
+            @RequestBody @Validated PlaceReviewRequestDto requestDto
+    ) {
 
         PlaceReviewResponseDto responseDto = placeReviewService
                 .modifyPlaceReview(principalDetails, placeReviewId, requestDto);
@@ -82,12 +83,12 @@ public class PlaceReviewController {
     }
 
     //todo : 로그인한 사람이 맞는지 확인
-    //todo : 복수형 s 붙이기가
     @DeleteMapping("/reviews")
-    public ResponseEntity<ResponseDTO<DeletePlaceReviewResponseDto>> removePlaceReview(
-            @RequestBody DeletePlaceReviewRequestDto requestDto) {
+    public ResponseEntity<ResponseDTO<DeletePlaceReviewResponseDto>> removePlaceReviews(
+            @RequestBody DeletePlaceReviewRequestDto requestDto
+    ) {
 
-        DeletePlaceReviewResponseDto responseDto = placeReviewService.deletePlaceReview(requestDto);
+        DeletePlaceReviewResponseDto responseDto = placeReviewService.deletePlaceReviews(requestDto);
 
         if (responseDto instanceof DeleteSomeFailurePlaceReviewResponseDto) {
             return ResponseEntity
@@ -103,6 +104,7 @@ public class PlaceReviewController {
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         Pageable pageable
     ) {
+
         List<PlaceReviewListResponseDto> responseDtos
             = placeReviewService.getMyPlaceReviewsList(principalDetails, pageable);
         ResponseDTO<List<PlaceReviewListResponseDto>> responseBody

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/PlaceReviewListResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/PlaceReviewListResponseDto.java
@@ -1,29 +1,29 @@
 package com.haejwo.tripcometrue.domain.review.placereview.dto.response;
 
 import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
+import org.springframework.data.domain.Page;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 public record PlaceReviewListResponseDto(
 
-    Long id,
-    String content,
-    String imageUrl,
-    Integer likeCount,
-    Long memberId,
-    Long placeId,
-    LocalDateTime createdAt
+        Long totalCount,
+        int nowPageNumber,
+        boolean isFirst,
+        boolean isLast,
+        List<PlaceReviewResponseDto> placeReviews
 
 ) {
-  public static PlaceReviewListResponseDto fromEntity(PlaceReview placeReview) {
-    return new PlaceReviewListResponseDto(
-        placeReview.getId(),
-        placeReview.getContent(),
-        placeReview.getImageUrl(),
-        placeReview.getLikeCount(),
-        placeReview.getMember().getId(),
-        placeReview.getPlace().getId(),
-        placeReview.getCreatedAt()
-    );
-  }
+    public static PlaceReviewListResponseDto fromResponseDtos(
+            Page<PlaceReview> reviews,
+            List<PlaceReviewResponseDto> placeReviews
+    ) {
+        return new PlaceReviewListResponseDto(
+                reviews.getTotalElements(),
+                reviews.getNumber(),
+                reviews.isFirst(),
+                reviews.isLast(),
+                placeReviews
+        );
+    }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/entity/PlaceReview.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/entity/PlaceReview.java
@@ -14,6 +14,8 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.haejwo.tripcometrue.domain.review.global.PointType.ONLY_ONE_POINT;
+import static com.haejwo.tripcometrue.domain.review.global.PointType.TWO_POINTS;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Getter
@@ -43,6 +45,7 @@ public class PlaceReview extends BaseTimeEntity {
     private String imageUrl;
     private Integer likeCount;
     private Integer commentCount;
+    private boolean hasAnyRegisteredPhotoUrl;
 
     @Builder
     public PlaceReview(Member member, Place place, String content, String imageUrl) {
@@ -52,8 +55,23 @@ public class PlaceReview extends BaseTimeEntity {
         this.imageUrl = imageUrl;
     }
 
-    public void update(PlaceReviewRequestDto requestDto) {
+    public void save(PlaceReviewRequestDto requestDto, Member member) {
+        if (requestDto.imageUrl() != null) {
+            member.earnPoint(TWO_POINTS.getPoint());
+            hasAnyRegisteredPhotoUrl = true;
+            return;
+        }
+
+        member.earnPoint(ONLY_ONE_POINT.getPoint());
+    }
+
+    public void update(PlaceReviewRequestDto requestDto, Member member) {
         this.content = requestDto.content();
+
+        if (!hasAnyRegisteredPhotoUrl && requestDto.imageUrl() != null) {
+            member.earnPoint(ONLY_ONE_POINT.getPoint());
+            hasAnyRegisteredPhotoUrl = true;
+        }
         this.imageUrl = requestDto.imageUrl();
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/repository/PlaceReviewRepository.java
@@ -3,8 +3,11 @@ package com.haejwo.tripcometrue.domain.review.placereview.repository;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,5 +17,6 @@ public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long>,
 
     boolean existsByMemberAndPlace(Member member, Place place);
 
-    List<PlaceReview> findByMemberId(Long memberId, Pageable pageable);
+    @Query("select pr from PlaceReview pr join fetch pr.member m where pr.member = :member order by pr.createdAt desc")
+    Page<PlaceReview> findByMember(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/repository/PlaceReviewRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/repository/PlaceReviewRepository.java
@@ -10,8 +10,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface PlaceReviewRepository extends JpaRepository<PlaceReview, Long>, PlaceReviewRepositoryCustom {
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/service/PlaceReviewService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/service/PlaceReviewService.java
@@ -2,6 +2,7 @@ package com.haejwo.tripcometrue.domain.review.placereview.service;
 
 import com.haejwo.tripcometrue.domain.likes.entity.PlaceReviewLikes;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.member.exception.UserInvalidAccessException;
 import com.haejwo.tripcometrue.domain.member.exception.UserNotFoundException;
 import com.haejwo.tripcometrue.domain.member.repository.MemberRepository;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
@@ -30,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -115,10 +117,17 @@ public class PlaceReviewService {
         Member loginMember = getMember(principalDetails);
         PlaceReview placeReview = getPlaceReviewById(placeReviewId);
 
+        validateRightMemberAccess(loginMember, placeReview);
         placeReview.update(requestDto, loginMember);
 
         return PlaceReviewResponseDto
                 .fromEntity(placeReview, hasLikedPlaceReview(principalDetails, placeReview));
+    }
+
+    private void validateRightMemberAccess(Member member, PlaceReview placeReview) {
+        if (!Objects.equals(placeReview.getMember().getId(), member.getId())) {
+            throw new UserInvalidAccessException();
+        }
     }
 
     @Transactional

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/service/PlaceReviewService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/service/PlaceReviewService.java
@@ -137,7 +137,7 @@ public class PlaceReviewService {
     }
 
     @Transactional
-    public DeletePlaceReviewResponseDto deletePlaceReview(DeletePlaceReviewRequestDto requestDto) {
+    public DeletePlaceReviewResponseDto deletePlaceReviews(DeletePlaceReviewRequestDto requestDto) {
 
         List<Long> placeReviewIds = requestDto.placeReviewIds();
         List<Long> failedIds = new ArrayList<>();

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/service/PlaceReviewService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/service/PlaceReviewService.java
@@ -137,7 +137,9 @@ public class PlaceReviewService {
     }
 
     @Transactional
-    public DeletePlaceReviewResponseDto deletePlaceReviews(DeletePlaceReviewRequestDto requestDto) {
+    public DeletePlaceReviewResponseDto deletePlaceReviews(
+            DeletePlaceReviewRequestDto requestDto
+    ) {
 
         List<Long> placeReviewIds = requestDto.placeReviewIds();
         List<Long> failedIds = new ArrayList<>();

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
@@ -143,22 +143,6 @@ public class TripRecordReviewService {
         }
     }
 
-    public TripRecordReviewListResponseDto getMyTripRecordReviewList(
-            PrincipalDetails principalDetails,
-            Pageable pageable
-    ) {
-
-        Page<TripRecordReview> reviews = tripRecordReviewRepository.findByMember(getMember(principalDetails), pageable);
-
-        List<TripRecordReviewResponseDto> responseDtos =
-                reviews.map(tripRecordReview -> TripRecordReviewResponseDto.fromEntity(
-                        tripRecordReview,
-                        hasLikedTripRecordReview(principalDetails, tripRecordReview))
-                ).toList();
-
-        return TripRecordReviewListResponseDto.fromResponseDtos(reviews, responseDtos);
-    }
-
     @Transactional
     public DeleteTripRecordReviewResponseDto deleteTripRecordReviews(
             DeleteTripRecordReviewRequestDto requestDto
@@ -228,6 +212,22 @@ public class TripRecordReviewService {
 
         TripRecord tripRecord = getTripRecordById(tripRecordId);
         Page<TripRecordReview> reviews = tripRecordReviewRepository.findByTripRecord(tripRecord, pageable);
+
+        return TripRecordReviewListResponseDto.fromResponseDtos(
+                reviews,
+                reviews.map(tripRecordReview -> TripRecordReviewResponseDto.fromEntity(
+                        tripRecordReview,
+                        hasLikedTripRecordReview(principalDetails, tripRecordReview))
+                ).toList());
+    }
+
+    public TripRecordReviewListResponseDto getMyTripRecordReviewList(
+            PrincipalDetails principalDetails,
+            Pageable pageable
+    ) {
+
+        Member loginMember = getMember(principalDetails);
+        Page<TripRecordReview> reviews = tripRecordReviewRepository.findByMember(loginMember, pageable);
 
         return TripRecordReviewListResponseDto.fromResponseDtos(
                 reviews,


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)
- [x] 리팩토링 (Refactoring)

- **간략한 설명**:
  : 여행지 리뷰 기능 추가 및 리팩토링을 진행했습니다.

---

## 🛠 작성/변경 사항

### - 여행지 리뷰 일부 삭제 성공 시 `207` 상태코드에서 `200` 상태 코드로 변경
  - 프론트엔드와 논의한 결과, 여행지 리뷰가 일부 성공하더라도 정책적으로 `200` 코드를 반환하기로 합의했습니다.
  - controller 계층 코드가 훨씬 깔끔해졌습니다.

### - 여행지 리뷰 목록 및 My 여행지 리뷰 목록 조회에서 DTO 변경
  - 기존 버전은 `Page 인터페이스`를 그대로 반환했기 때문에 불필요한 정보까지 전달했습니다.
  - Page 인터페이스에서 중요한 정보만 추출해서 `PlaceReviewListResponseDto` 로 반환합니다.
    - `Long totalCount`  :  조회한 총 개수
    - `int nowPageNumber`  :  현재 페이지 넘버
    - `boolean isFirst`  :  현재 페이지가 처음인지 여부
    - `boolean isLast`  :  현재 페이지가 마지막인지 여부
    - `List<PlaceReviewResponseDto> placeReviews`  :  PlaceReview 리스트

### - 여행지 리뷰 등록 및 수정 시 이미지 중복 등록으로 인한 포인트 부정 적립 방지 기능 추가
  - 여행지 리뷰를 등록할 때 이미지를 등록하지 않았다가, 수정 API를 통해 처음 이미지를 등록할 시 포인트 +1점 적립합니다.
  - 만약 수정 API에서 이미지를 삭제해 `null`로 만든 후, 다시 이미지를 등록하면 부정 적립으로 판단하고 포인트를 적립하지 않습니다.

### - 여행지 리뷰 수정 시 타인의 리뷰 수정하지 못하도록 예외 발생 구현
  - 만약 로그인한 사용자가 작성하지 않은 리뷰를 수정하려고 할 시 `UserInvalidAccessException` 예외가 발생합니다.

### - 여행지 리뷰 등록 시 비영속 상태인 `member`를 영속화 하기 위해 `merge()` 대신 `memberRepository`에서 꺼내오는 방법으로 변경

### - 기타 코드 인라인 정리, 주석 및 import 문 정리 
 
---

## 🔗 관련 이슈

- **이슈 링크1** : #95 
