### PR TITLE
[feat] 홈 피드 API 2차 구현

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityContentReadController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityContentReadController.java
@@ -3,6 +3,7 @@ package com.haejwo.tripcometrue.domain.city.controller;
 import com.haejwo.tripcometrue.domain.city.dto.response.*;
 import com.haejwo.tripcometrue.domain.city.service.CityContentReadService;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import com.haejwo.tripcometrue.global.util.SliceResponseDto;
 import com.haejwo.tripcometrue.global.validator.annotation.HomeTopListQueryType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -51,7 +52,7 @@ public class CityContentReadController {
 
     // 도시 갤러리 더보기 조회
     @GetMapping("/{cityId}/images")
-    public ResponseEntity<ResponseDTO<SliceResponse<CityImageContentResponseDto>>> getImagesByCityIdPagination(
+    public ResponseEntity<ResponseDTO<SliceResponseDto<CityImageContentResponseDto>>> getImagesByCityIdPagination(
         @PathVariable("cityId") Long cityId,
         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
         ) {
@@ -80,7 +81,7 @@ public class CityContentReadController {
 
     // 도시 쇼츠 더보기 조회
     @GetMapping("/{cityId}/videos")
-    public ResponseEntity<ResponseDTO<SliceResponse<CityVideoContentResponseDto>>> getVideosByCityIdPagination(
+    public ResponseEntity<ResponseDTO<SliceResponseDto<CityVideoContentResponseDto>>> getVideosByCityIdPagination(
         @PathVariable("cityId") Long cityId,
         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
@@ -121,7 +122,7 @@ public class CityContentReadController {
 
     // 도시 여행지 더보기 조회
     @GetMapping("/{cityId}/places")
-    public ResponseEntity<ResponseDTO<SliceResponse<CityPlaceResponseDto>>> getPlacesByCityIdPagination(
+    public ResponseEntity<ResponseDTO<SliceResponseDto<CityPlaceResponseDto>>> getPlacesByCityIdPagination(
         @PathVariable("cityId") Long cityId,
         @PageableDefault(sort = "storedCount", direction = Sort.Direction.DESC) Pageable pageable
     ) {

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CitySearchController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CitySearchController.java
@@ -1,0 +1,34 @@
+package com.haejwo.tripcometrue.domain.city.controller;
+
+import com.haejwo.tripcometrue.domain.city.dto.response.CityResponseDto;
+import com.haejwo.tripcometrue.domain.city.service.CitySearchService;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/cities")
+@RestController
+public class CitySearchController {
+
+    private final CitySearchService citySearchService;
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<List<CityResponseDto>>> search(
+        @RequestParam("name") String name
+    ) {
+        return ResponseEntity
+            .ok()
+            .body(
+                ResponseDTO.okWithData(
+                    citySearchService.search(name)
+                )
+            );
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityInfoResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityInfoResponseDto.java
@@ -3,6 +3,8 @@ package com.haejwo.tripcometrue.domain.city.dto.response;
 import com.haejwo.tripcometrue.domain.city.entity.City;
 import lombok.Builder;
 
+import java.util.Objects;
+
 public record CityInfoResponseDto(
     Long id,
     String name,
@@ -26,8 +28,12 @@ public record CityInfoResponseDto(
             .timeDifference(entity.getTimeDifference())
             .voltage(entity.getVoltage())
             .visa(entity.getVisa())
-            .curUnit(entity.getCurrency().toString())
-            .curName(entity.getCurrency().getCurrencyName())
+            .curUnit(
+                Objects.nonNull(entity.getCurrency()) ? entity.getCurrency().name() : null
+            )
+            .curName(
+                Objects.nonNull(entity.getCurrency()) ? entity.getCurrency().getCurrencyName() : null
+            )
             .build();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.haejwo.tripcometrue.domain.city.entity.City;
 import lombok.Builder;
 
+import java.util.Objects;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CityResponseDto(
     Long id,
@@ -12,7 +14,8 @@ public record CityResponseDto(
     String timeDifference,
     String voltage,
     String visa,
-    String currency,
+    String curUnit,
+    String exchangeRate,
     String weatherRecommendation,
     String weatherDescription,
     String country
@@ -22,7 +25,7 @@ public record CityResponseDto(
     public CityResponseDto {
     }
 
-    public static CityResponseDto fromEntity(City entity) {
+    public static CityResponseDto fromEntity(City entity, String exchangeRate) {
         return CityResponseDto.builder()
             .id(entity.getId())
             .name(entity.getName())
@@ -30,7 +33,10 @@ public record CityResponseDto(
             .timeDifference(entity.getTimeDifference())
             .voltage(entity.getVoltage())
             .visa(entity.getVisa())
-            .currency(entity.getCurrency().name())
+            .curUnit(
+                Objects.nonNull(entity.getCurrency()) ? entity.getCurrency().name() : null
+            )
+            .exchangeRate(exchangeRate)
             .weatherRecommendation(entity.getWeatherRecommendation())
             .weatherDescription(entity.getWeatherDescription())
             .country(entity.getCountry().getDescription())

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
@@ -25,6 +25,24 @@ public record CityResponseDto(
     public CityResponseDto {
     }
 
+    public static CityResponseDto fromEntity(City entity) {
+        return CityResponseDto.builder()
+            .id(entity.getId())
+            .name(entity.getName())
+            .language(entity.getLanguage())
+            .timeDifference(entity.getTimeDifference())
+            .voltage(entity.getVoltage())
+            .visa(entity.getVisa())
+            .curUnit(
+                Objects.nonNull(entity.getCurrency()) ? entity.getCurrency().name() : null
+            )
+            .exchangeRate(null)
+            .weatherRecommendation(entity.getWeatherRecommendation())
+            .weatherDescription(entity.getWeatherDescription())
+            .country(entity.getCountry().getDescription())
+            .build();
+    }
+
     public static CityResponseDto fromEntity(City entity, String exchangeRate) {
         return CityResponseDto.builder()
             .id(entity.getId())

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface CityRepositoryCustom {
     List<City> findTopCityListDomestic(int size);
 
     List<City> findTopCityListOverseas(int size);
+
+    List<City> findBySearchParams(String name);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/repository/CityRepositoryImpl.java
@@ -2,8 +2,11 @@ package com.haejwo.tripcometrue.domain.city.repository;
 
 import com.haejwo.tripcometrue.domain.city.entity.City;
 import com.haejwo.tripcometrue.global.enums.Country;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -32,5 +35,29 @@ public class CityRepositoryImpl implements CityRepositoryCustom {
             .orderBy(city.storeCount.desc())
             .limit(size)
             .fetch();
+    }
+
+    @Override
+    public List<City> findBySearchParams(String name) {
+        return queryFactory
+            .selectFrom(city)
+            .where(
+                containsIgnoreCaseName(name)
+            )
+            .orderBy(city.storeCount.desc())
+            .fetch();
+    }
+
+    private BooleanExpression containsIgnoreCaseName(String name) {
+
+        if (!StringUtils.hasText(name)) {
+            return null;
+        }
+
+        String replacedName = name.replaceAll(" ", "");
+
+        return Expressions.stringTemplate(
+            "function('replace',{0},{1},{2})", city.name, " ", ""
+            ).containsIgnoreCase(replacedName);
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityContentReadService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityContentReadService.java
@@ -9,6 +9,7 @@ import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
 import com.haejwo.tripcometrue.domain.triprecord.dto.query.TripRecordScheduleImageWithPlaceIdQueryDto;
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_image.TripRecordScheduleImageRepository;
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_video.TripRecordScheduleVideoRepository;
+import com.haejwo.tripcometrue.global.util.SliceResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -86,12 +87,12 @@ public class CityContentReadService {
 
     // 도시 여행지 전체 조회 (스크롤 페이징)
     @Transactional(readOnly = true)
-    public SliceResponse<CityPlaceResponseDto> getPlaces(Long cityId, Pageable pageable) {
+    public SliceResponseDto<CityPlaceResponseDto> getPlaces(Long cityId, Pageable pageable) {
         Slice<Place> places = placeRepository.findPlacesByCityId(cityId, pageable);
 
         Map<Long, List<TripRecordScheduleImageWithPlaceIdQueryDto>> imageMap = getImageMapFromPlaceIds(places.getContent());
 
-        return SliceResponse.of(
+        return SliceResponseDto.of(
             places
                 .map(place -> {
                     String imageUrl = imageMap.get(place.getId()).get(0).imageUrl();
@@ -111,8 +112,8 @@ public class CityContentReadService {
 
     // 도시 갤러리 리스트 조회 (페이징, 정렬)
     @Transactional(readOnly = true)
-    public SliceResponse<CityImageContentResponseDto> getImages(Long cityId, Pageable pageable) {
-        return SliceResponse.of(
+    public SliceResponseDto<CityImageContentResponseDto> getImages(Long cityId, Pageable pageable) {
+        return SliceResponseDto.of(
             tripRecordScheduleImageRepository.findByCityId(cityId, pageable)
                 .map(CityImageContentResponseDto::fromEntity)
         );
@@ -130,8 +131,8 @@ public class CityContentReadService {
 
     // 도시 쇼츠 리스트 조회 (페이징, 정렬)
     @Transactional(readOnly = true)
-    public SliceResponse<CityVideoContentResponseDto> getVideos(Long cityId, Pageable pageable) {
-        return SliceResponse.of(
+    public SliceResponseDto<CityVideoContentResponseDto> getVideos(Long cityId, Pageable pageable) {
+        return SliceResponseDto.of(
             tripRecordScheduleVideoRepository
                 .findByCityId(cityId, pageable)
                 .map(CityVideoContentResponseDto::fromEntity)

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/CitySearchService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/CitySearchService.java
@@ -1,0 +1,45 @@
+package com.haejwo.tripcometrue.domain.city.service;
+
+import com.haejwo.tripcometrue.domain.city.dto.response.CityResponseDto;
+import com.haejwo.tripcometrue.domain.city.entity.City;
+import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Service
+public class CitySearchService {
+
+    private final CityRepository cityRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String EXCHANGE_RATE_REDIS_KEY_PREFIX = "exchange-rate:";
+
+    @Transactional(readOnly = true)
+    public List<CityResponseDto> search(String name) {
+        return cityRepository
+            .findBySearchParams(name)
+            .stream()
+            .map(city -> {
+                    String exchangeRate = getExchangeRate(city);
+                    return CityResponseDto.fromEntity(city, exchangeRate);
+                }
+            )
+            .toList();
+    }
+
+    private String getExchangeRate(City city) {
+        CurrencyUnit currency = city.getCurrency();
+        if (Objects.isNull(currency)) {
+            return null;
+        }
+
+        return (String) redisTemplate.opsForValue()
+            .get(EXCHANGE_RATE_REDIS_KEY_PREFIX + currency.name());
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/controller/MemberSearchController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/controller/MemberSearchController.java
@@ -1,0 +1,51 @@
+package com.haejwo.tripcometrue.domain.member.controller;
+
+import com.haejwo.tripcometrue.domain.member.dto.response.MemberDetailListItemResponseDto;
+import com.haejwo.tripcometrue.domain.member.dto.response.MemberSearchResultWithContentResponseDto;
+import com.haejwo.tripcometrue.domain.member.facade.MemberSearchFacade;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import com.haejwo.tripcometrue.global.util.SliceResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/members")
+@RestController
+public class MemberSearchController {
+
+    private final MemberSearchFacade memberSearchFacade;
+
+    @GetMapping("/list")
+    public ResponseEntity<ResponseDTO<MemberSearchResultWithContentResponseDto>> searchByNicknameResultWithContent(
+        @RequestParam("query") String query
+    ) {
+        return ResponseEntity
+            .ok()
+            .body(
+                ResponseDTO.okWithData(
+                    memberSearchFacade.searchByNicknameResultWithContent(query)
+                )
+            );
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<SliceResponseDto<MemberDetailListItemResponseDto>>> searchByNicknamePagination(
+        @RequestParam("query") String query,
+        @PageableDefault(sort = "rating", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity
+            .ok()
+            .body(
+                ResponseDTO.okWithData(
+                    memberSearchFacade.searchByNicknamePagination(query, pageable)
+                )
+            );
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/dto/response/MemberDetailListItemResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/dto/response/MemberDetailListItemResponseDto.java
@@ -1,0 +1,30 @@
+package com.haejwo.tripcometrue.domain.member.dto.response;
+
+import lombok.Builder;
+
+public record MemberDetailListItemResponseDto(
+    Long id,
+    String nickname,
+    String introduction,
+    String profileUrl,
+    Double avgRate,
+    Integer tripRecordTotal,
+    Integer videoTotal
+) {
+
+    @Builder
+    public MemberDetailListItemResponseDto {
+    }
+
+    public static MemberDetailListItemResponseDto of(MemberListItemResponseDto dto, Integer tripRecordTotal, Integer videoTotal) {
+        return MemberDetailListItemResponseDto.builder()
+            .id(dto.id())
+            .nickname(dto.nickname())
+            .introduction(dto.introduction())
+            .profileUrl(dto.profileUrl())
+            .avgRate(dto.avgRate())
+            .tripRecordTotal(tripRecordTotal)
+            .videoTotal(videoTotal)
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/dto/response/MemberListItemResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/dto/response/MemberListItemResponseDto.java
@@ -1,0 +1,27 @@
+package com.haejwo.tripcometrue.domain.member.dto.response;
+
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import lombok.Builder;
+
+public record MemberListItemResponseDto(
+    Long id,
+    String nickname,
+    String introduction,
+    String profileUrl,
+    Double avgRate
+) {
+
+    @Builder
+    public MemberListItemResponseDto {
+    }
+
+    public static MemberListItemResponseDto fromEntity(Member entity) {
+        return MemberListItemResponseDto.builder()
+            .id(entity.getId())
+            .nickname(entity.getMemberBase().getNickname())
+            .introduction(entity.getIntroduction())
+            .profileUrl(entity.getProfileImage())
+            .avgRate(entity.getMemberRating())
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/dto/response/MemberSearchResultWithContentResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/dto/response/MemberSearchResultWithContentResponseDto.java
@@ -1,0 +1,18 @@
+package com.haejwo.tripcometrue.domain.member.dto.response;
+
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListItemResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media.TripRecordScheduleVideoListItemResponseDto;
+import lombok.Builder;
+
+import java.util.List;
+
+public record MemberSearchResultWithContentResponseDto(
+    List<MemberListItemResponseDto> members,
+    List<TripRecordScheduleVideoListItemResponseDto> videos,
+    List<TripRecordListItemResponseDto> tripRecords
+) {
+
+    @Builder
+    public MemberSearchResultWithContentResponseDto {
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/dto/response/ProfileImageResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/dto/response/ProfileImageResponseDto.java
@@ -4,6 +4,6 @@ import com.haejwo.tripcometrue.domain.member.entity.Member;
 
 public record ProfileImageResponseDto(String profileImageUrl) {
   public static ProfileImageResponseDto fromEntity(Member member) {
-    return new ProfileImageResponseDto(member.getProfile_image());
+    return new ProfileImageResponseDto(member.getProfileImage());
   }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/entity/Member.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/entity/Member.java
@@ -11,12 +11,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
-import jakarta.persistence.*;
-import jakarta.persistence.PrePersist;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -33,28 +33,29 @@ public class Member extends BaseTimeEntity {
 
     private String provider;
 
-    private String profile_image;
+    private String profileImage;
 
-    private Integer total_point;
+    private Integer totalPoint;
 
     @Enumerated(EnumType.STRING)
-    private MilkLevel milk_level;
+    private MilkLevel milkLevel;
 
     private String introduction;
 
     private Integer nickNameChangeCount;
 
-//    private double member_rating;
+    private Double memberRating;
 
     @Builder
     public Member(String email, String nickname, String password, String authority,
-        String provider) {
+        String provider, Double memberRating) {
         this.memberBase = new MemberBase(email, nickname, password, authority);
         this.provider = provider;
+        this.memberRating = Objects.isNull(memberRating) ? 0.0 : memberRating;
     }
 
     public void updateProfileImage(String profileImage){
-        this.profile_image = profileImage;
+        this.profileImage = profileImage;
     }
 
     public void updateIntroduction(String introduction){
@@ -66,17 +67,17 @@ public class Member extends BaseTimeEntity {
     }
 
     public void updateMilkLevel(){
-        this.milk_level= MilkLevel.getLevelByPoint(this.total_point);
+        this.milkLevel = MilkLevel.getLevelByPoint(this.totalPoint);
     }
 
     public void earnPoint(int point) {
-        this.total_point += point;
+        this.totalPoint += point;
         updateMilkLevel();
     }
 
     @PrePersist
     private void init(){
-        total_point = (total_point == null) ? 0 : total_point;
+        totalPoint = (totalPoint == null) ? 0 : totalPoint;
         nickNameChangeCount = (nickNameChangeCount == null) ? 0 : nickNameChangeCount;
         updateMilkLevel();
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/facade/MemberSearchFacade.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/facade/MemberSearchFacade.java
@@ -1,0 +1,97 @@
+package com.haejwo.tripcometrue.domain.member.facade;
+
+import com.haejwo.tripcometrue.domain.member.dto.response.MemberDetailListItemResponseDto;
+import com.haejwo.tripcometrue.domain.member.dto.response.MemberListItemResponseDto;
+import com.haejwo.tripcometrue.domain.member.dto.response.MemberSearchResultWithContentResponseDto;
+import com.haejwo.tripcometrue.domain.member.service.MemberSearchService;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListItemResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListItemWithMemberIdResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media.TripRecordScheduleVideoListItemResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.service.TripRecordScheduleVideoService;
+import com.haejwo.tripcometrue.domain.triprecord.service.TripRecordService;
+import com.haejwo.tripcometrue.global.util.SliceResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MemberSearchFacade {
+
+    private final MemberSearchService memberSearchService;
+    private final TripRecordScheduleVideoService tripRecordScheduleVideoService;
+    private final TripRecordService tripRecordService;
+
+    public MemberSearchResultWithContentResponseDto searchByNicknameResultWithContent(String nickname) {
+        List<MemberListItemResponseDto> members = memberSearchService.searchByNickname(nickname);
+
+        List<Long> memberIds = members
+            .stream()
+            .map(MemberListItemResponseDto::id)
+            .toList();
+
+        List<TripRecordScheduleVideoListItemResponseDto> videos = tripRecordScheduleVideoService.getVideosInMemberIds(memberIds);
+        List<TripRecordListItemResponseDto> tripRecords = tripRecordService.findTripRecordsInMemberIds(memberIds);
+
+        return MemberSearchResultWithContentResponseDto.builder()
+            .members(members)
+            .videos(videos)
+            .tripRecords(tripRecords)
+            .build();
+    }
+
+    public SliceResponseDto<MemberDetailListItemResponseDto> searchByNicknamePagination(String query, Pageable pageable) {
+
+        SliceResponseDto<MemberListItemResponseDto> sliceResult = memberSearchService.searchByNickname(query, pageable);
+
+        List<Long> memberIds = sliceResult.content()
+            .stream()
+            .map(MemberListItemResponseDto::id)
+            .toList();
+
+        Map<Long, List<TripRecordListItemWithMemberIdResponseDto>> tripRecordMap = getGroupByMemberIdTripRecordMap(memberIds);
+
+        Map<Long, List<TripRecordScheduleVideoListItemResponseDto>> videoMap = getGroupByMemberIdVideoMap(memberIds);
+
+
+        return SliceResponseDto.<MemberDetailListItemResponseDto>builder()
+            .content(
+                sliceResult.content()
+                    .stream()
+                    .map(dto -> {
+                            int tripRecordTotal = (Objects.isNull(tripRecordMap.get(dto.id()))) ? 0 : tripRecordMap.get(dto.id()).size();
+                            int videoTotal = (Objects.isNull(videoMap.get(dto.id()))) ? 0 : videoMap.get(dto.id()).size();
+
+                            return MemberDetailListItemResponseDto.of(dto, tripRecordTotal, videoTotal);
+                        }
+                    )
+                    .toList()
+            )
+            .totalCount(sliceResult.totalCount())
+            .currentPageNum(sliceResult.currentPageNum())
+            .pageSize(sliceResult.pageSize())
+            .sort(sliceResult.sort())
+            .first(sliceResult.first())
+            .last(sliceResult.last())
+            .build();
+    }
+
+    private Map<Long, List<TripRecordScheduleVideoListItemResponseDto>> getGroupByMemberIdVideoMap(List<Long> memberIds) {
+        return tripRecordScheduleVideoService.getVideosInMemberIds(memberIds)
+            .stream()
+            .collect(Collectors.groupingBy(TripRecordScheduleVideoListItemResponseDto::memberId));
+    }
+
+    private Map<Long, List<TripRecordListItemWithMemberIdResponseDto>> getGroupByMemberIdTripRecordMap(List<Long> memberIds) {
+        return tripRecordService.findTripRecordsWihMemberInMemberIds(memberIds)
+            .stream()
+            .collect(Collectors.groupingBy(TripRecordListItemWithMemberIdResponseDto::memberId));
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/repository/MemberRepository.java
@@ -4,7 +4,8 @@ import com.haejwo.tripcometrue.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository
+    extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
     Optional<Member> findByMemberBaseEmail(String email);
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.haejwo.tripcometrue.domain.member.repository;
+
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public interface MemberRepositoryCustom {
+
+    List<Member> findByNicknameOrderByMemberRating(String nickname);
+
+    Slice<Member> findByNicknameOrderByMemberRating(String nickname, Pageable pageable);
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.haejwo.tripcometrue.domain.member.repository;
+
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.haejwo.tripcometrue.domain.member.entity.QMember.member;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Member> findByNicknameOrderByMemberRating(String nickname) {
+        return queryFactory
+            .selectFrom(member)
+            .where(
+                containsIgnoreCaseNickname(nickname)
+            )
+            .orderBy(member.memberRating.desc())
+            .fetch();
+    }
+
+    @Override
+    public Slice<Member> findByNicknameOrderByMemberRating(String nickname, Pageable pageable) {
+
+        int pageSize = pageable.getPageSize();
+
+        List<Member> content = queryFactory
+            .selectFrom(member)
+            .where(
+                containsIgnoreCaseNickname(nickname)
+            )
+            .orderBy(member.memberRating.desc())
+            .offset(pageable.getOffset())
+            .limit(pageSize + 1)
+            .fetch();
+
+        boolean hasNext = false;
+        if (content.size() > pageSize) {
+            content.remove(pageSize);
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    private BooleanExpression containsIgnoreCaseNickname(String nickname) {
+
+        if (!StringUtils.hasText(nickname)) {
+            return null;
+        }
+
+        String replacedNickname = nickname.replaceAll(" ", "");
+
+        return Expressions.stringTemplate("function('replace',{0},{1},{2})", member.memberBase.nickname, " ", "")
+            .containsIgnoreCase(replacedNickname);
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/member/service/MemberSearchService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/service/MemberSearchService.java
@@ -1,0 +1,37 @@
+package com.haejwo.tripcometrue.domain.member.service;
+
+import com.haejwo.tripcometrue.domain.member.dto.response.MemberListItemResponseDto;
+import com.haejwo.tripcometrue.domain.member.repository.MemberRepository;
+import com.haejwo.tripcometrue.global.util.SliceResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class MemberSearchService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public List<MemberListItemResponseDto> searchByNickname(String nickname) {
+        return memberRepository
+            .findByNicknameOrderByMemberRating(nickname)
+            .stream()
+            .map(MemberListItemResponseDto::fromEntity)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public SliceResponseDto<MemberListItemResponseDto> searchByNickname(String nickname, Pageable pageable) {
+
+        return SliceResponseDto.of(
+            memberRepository
+                .findByNicknameOrderByMemberRating(nickname, pageable)
+                .map(MemberListItemResponseDto::fromEntity)
+        );
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/PlaceReviewResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/PlaceReviewResponseDto.java
@@ -27,7 +27,7 @@ public record PlaceReviewResponseDto(
                         placeReview.getId(),
                         placeReview.getMember().getId(),
                         placeReview.getMember().getMemberBase().getNickname(),
-                        placeReview.getMember().getProfile_image(),
+                        placeReview.getMember().getProfileImage(),
                         placeReview.getImageUrl(),
                         placeReview.getContent(),
                         placeReview.getLikeCount(),

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/RegisterPlaceReviewResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/RegisterPlaceReviewResponseDto.java
@@ -23,7 +23,7 @@ public record RegisterPlaceReviewResponseDto(
                 placeReview.getId(),
                 placeReview.getMember().getId(),
                 placeReview.getMember().getMemberBase().getNickname(),
-                placeReview.getMember().getProfile_image(),
+                placeReview.getMember().getProfileImage(),
                 placeReview.getImageUrl(),
                 placeReview.getContent(),
                 placeReview.getCreatedAt()

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/dto/response/TripRecordStoreResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/dto/response/TripRecordStoreResponseDto.java
@@ -12,7 +12,7 @@ public record TripRecordStoreResponseDto(
     LocalDate tripStartDay,
     LocalDate tripEndDay,
     Integer totalDays,
-    Integer averageRating,
+    Double averageRating,
     Integer viewCount
 ) {
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
@@ -64,6 +64,7 @@ public class TripRecordController {
 
     }
 
+    // 홈 피드 TOP 인기 여행 후기 리스트 조회
     @GetMapping("/top-list")
     public ResponseEntity<ResponseDTO<List<TopTripRecordResponseDto>>> tripRecordTopList(
         @RequestParam("type") @HomeTopListQueryType String type

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/query/TripRecordScheduleVideoQueryDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/query/TripRecordScheduleVideoQueryDto.java
@@ -1,0 +1,12 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.query;
+
+public record TripRecordScheduleVideoQueryDto(
+    Long id,
+    Long tripRecordId,
+    String tripRecordTitle,
+    String thumbnailUrl,
+    String videoUrl,
+    Integer storedCount,
+    Long memberId
+) {
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/member/TripRecordMemberResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/member/TripRecordMemberResponseDto.java
@@ -17,7 +17,7 @@ public record TripRecordMemberResponseDto(
     public static TripRecordMemberResponseDto fromEntity(Member entity) {
         return TripRecordMemberResponseDto.builder()
             .nickname(entity.getMemberBase().getNickname())
-            .profileImage(entity.getProfile_image())
+            .profileImage(entity.getProfileImage())
             .build();
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TopTripRecordResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TopTripRecordResponseDto.java
@@ -39,7 +39,7 @@ public record TopTripRecordResponseDto(
             .tripRecordTitle(entity.getTitle())
             .memberId(member.getId())
             .memberName(member.getMemberBase().getNickname())
-            .profileImageUrl(member.getProfile_image())
+            .profileImageUrl(member.getProfileImage())
             .cityNames(cityNames)
             .totalDays(entity.getTotalDays())
             .storedCount(entity.getStoreCount())

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordDetailResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordDetailResponseDto.java
@@ -27,7 +27,7 @@ public record TripRecordDetailResponseDto(
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd") LocalDate tripStartDay,
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd") LocalDate tripEndDay,
     Integer totalDays,
-    Integer average_rating,
+    Double averageRating,
     Integer storeCount,
     TripRecordMemberResponseDto member,
     List<TripRecordImageResponseDto> images,
@@ -41,7 +41,7 @@ public record TripRecordDetailResponseDto(
         ExpenseRangeType expenseRangeType, String countries,
         @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd") LocalDate tripStartDay,
         @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd") LocalDate tripEndDay,
-        Integer totalDays, Integer average_rating, Integer storeCount,
+        Integer totalDays, Double averageRating, Integer storeCount,
         TripRecordMemberResponseDto member, List<TripRecordImageResponseDto> images,
         List<TripRecordTagResponseDto> tags,
         Map<Integer, List<TripRecordScheduleDetailResponseDto>> schedules) {
@@ -53,7 +53,7 @@ public record TripRecordDetailResponseDto(
         this.tripStartDay = tripStartDay;
         this.tripEndDay = tripEndDay;
         this.totalDays = totalDays;
-        this.average_rating = average_rating;
+        this.averageRating = averageRating;
         this.storeCount = storeCount;
         this.member = member;
         this.images = images;
@@ -93,7 +93,7 @@ public record TripRecordDetailResponseDto(
             .tripEndDay(entity.getTripEndDay())
             .totalDays(entity.getTotalDays())
             .storeCount(entity.getStoreCount())
-            .average_rating(entity.getAverageRating())
+            .averageRating(entity.getAverageRating())
             .member(member)
             .images(imageDtos)
             .tags(tagDtos)

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordListItemResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordListItemResponseDto.java
@@ -1,0 +1,35 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord;
+
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordImage;
+import lombok.Builder;
+
+import java.util.Objects;
+
+public record TripRecordListItemResponseDto(
+    Long id,
+    String title,
+    Integer storedCount,
+    String imageUrl
+) {
+
+    @Builder
+    public TripRecordListItemResponseDto {
+    }
+
+    public static TripRecordListItemResponseDto fromEntity(TripRecord entity) {
+        return TripRecordListItemResponseDto.builder()
+            .id(entity.getId())
+            .title(entity.getTitle())
+            .storedCount(entity.getStoreCount())
+            .imageUrl(
+                entity.getTripRecordImages()
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .map(TripRecordImage::getImageUrl)
+                    .orElse(null)
+            )
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordListItemWithMemberIdResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordListItemWithMemberIdResponseDto.java
@@ -1,0 +1,37 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord;
+
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordImage;
+import lombok.Builder;
+
+import java.util.Objects;
+
+public record TripRecordListItemWithMemberIdResponseDto(
+    Long id,
+    String title,
+    Integer storedCount,
+    String imageUrl,
+    Long memberId
+) {
+
+    @Builder
+    public TripRecordListItemWithMemberIdResponseDto {
+    }
+
+    public static TripRecordListItemWithMemberIdResponseDto fromEntity(TripRecord entity) {
+        return TripRecordListItemWithMemberIdResponseDto.builder()
+            .id(entity.getId())
+            .title(entity.getTitle())
+            .storedCount(entity.getStoreCount())
+            .imageUrl(
+                entity.getTripRecordImages()
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .map(TripRecordImage::getImageUrl)
+                    .orElse(null)
+            )
+            .memberId(entity.getMember().getId())
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordResponseDto.java
@@ -16,7 +16,7 @@ public record TripRecordResponseDto(
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") LocalDate tripEndDay,
     Integer totalDays,
     Integer viewCount,
-    Integer average_rating,
+    Double averageRating,
     Long memberId
 
 ) {
@@ -24,7 +24,7 @@ public record TripRecordResponseDto(
     @Builder
     public TripRecordResponseDto(Long id, String title, String content,
         ExpenseRangeType expenseRangeType, String countries, LocalDate tripStartDay, LocalDate tripEndDay,
-        Integer totalDays, Integer viewCount, Integer average_rating, Long memberId) {
+        Integer totalDays, Integer viewCount, Double averageRating, Long memberId) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -34,7 +34,7 @@ public record TripRecordResponseDto(
         this.tripEndDay = tripEndDay;
         this.totalDays = totalDays;
         this.viewCount = viewCount;
-        this.average_rating = average_rating;
+        this.averageRating = averageRating;
         this.memberId = memberId;
     }
 
@@ -49,7 +49,7 @@ public record TripRecordResponseDto(
             .tripEndDay(entity.getTripEndDay())
             .totalDays(entity.getTotalDays())
             .viewCount(entity.getViewCount())
-            .average_rating(entity.getAverageRating())
+            .averageRating(entity.getAverageRating())
             .memberId(entity.getMember().getId())
             .build();
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule_media/TripRecordScheduleVideoItemResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule_media/TripRecordScheduleVideoItemResponseDto.java
@@ -1,9 +1,0 @@
-package com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media;
-
-public record TripRecordScheduleVideoItemResponseDto(
-    Long tripRecordId,
-    String tripRecordTitle,
-    Integer storedCount,
-    String thumbnail
-) {
-}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule_media/TripRecordScheduleVideoListItemResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule_media/TripRecordScheduleVideoListItemResponseDto.java
@@ -1,0 +1,31 @@
+package com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media;
+
+import com.haejwo.tripcometrue.domain.triprecord.dto.query.TripRecordScheduleVideoQueryDto;
+import lombok.Builder;
+
+public record TripRecordScheduleVideoListItemResponseDto(
+    Long id,
+    Long tripRecordId,
+    String tripRecordTitle,
+    String thumbnailUrl,
+    String videoUrl,
+    Integer storedCount,
+    Long memberId
+) {
+
+    @Builder
+    public TripRecordScheduleVideoListItemResponseDto {
+    }
+
+    public static TripRecordScheduleVideoListItemResponseDto fromQueryDto(TripRecordScheduleVideoQueryDto dto) {
+        return TripRecordScheduleVideoListItemResponseDto.builder()
+            .id(dto.id())
+            .tripRecordId(dto.tripRecordId())
+            .tripRecordTitle(dto.tripRecordTitle())
+            .thumbnailUrl(dto.thumbnailUrl())
+            .videoUrl(dto.videoUrl())
+            .storedCount(dto.storedCount())
+            .memberId(dto.memberId())
+            .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecord.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/entity/TripRecord.java
@@ -51,7 +51,7 @@ public class TripRecord extends BaseTimeEntity {
     private LocalDate tripEndDay;
 
     private Integer totalDays;
-    private Integer averageRating;
+    private Double averageRating;
     private Integer viewCount;
     private Integer storeCount;
     private Integer reviewCount;
@@ -77,7 +77,7 @@ public class TripRecord extends BaseTimeEntity {
     @Builder
     public TripRecord(Long id, String title, String content, ExpenseRangeType expenseRangeType,
         String countries, LocalDate tripStartDay, LocalDate tripEndDay, Integer totalDays,
-        Integer averageRating, Integer viewCount, Integer storeCount, Integer reviewCount,
+        Double averageRating, Integer viewCount, Integer storeCount, Integer reviewCount,
         Integer commentCount, List<TripRecordSchedule> tripRecordSchedules,
         List<TripRecordTag> tripRecordTags, List<TripRecordImage> tripRecordImages,
         List<TripRecordStore> tripRecordStores, Member member) {

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepository.java
@@ -16,4 +16,8 @@ public interface TripRecordCustomRepository {
     List<TripRecord> findTopTripRecordListOverseas(int size);
 
     List<TripRecordHotShortsListResponseDto> findTripRecordHotShortsList(Pageable pageable);
+
+    List<TripRecord> findTripRecordListInMemberIds(List<Long> memberIds);
+
+    List<TripRecord> findTripRecordListWithMemberInMemberIds(List<Long> memberIds);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
@@ -109,7 +109,7 @@ public class TripRecordCustomRepositoryImpl extends QuerydslRepositorySupport im
                     .select(qTripRecordImage.imageUrl.min())
                     .from(qTripRecordImage)
                     .where(qTripRecordImage.tripRecord.id.eq(qTripRecord.id)),
-                Projections.constructor(TripRecordMemberResponseDto.class, qMember.memberBase.nickname, qMember.profile_image)
+                Projections.constructor(TripRecordMemberResponseDto.class, qMember.memberBase.nickname, qMember.profileImage)
             ))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
@@ -182,4 +182,28 @@ public class TripRecordCustomRepositoryImpl extends QuerydslRepositorySupport im
         return result;
     }
 
+
+    @Override
+    public List<TripRecord> findTripRecordListInMemberIds(List<Long> memberIds) {
+        QTripRecord tripRecord = QTripRecord.tripRecord;
+        QMember member = QMember.member;
+
+        return queryFactory.selectFrom(tripRecord)
+            .join(tripRecord.member, member)
+            .where(member.id.in(memberIds))
+            .orderBy(tripRecord.storeCount.desc(), tripRecord.createdAt.desc())
+            .fetch();
+    }
+
+    @Override
+    public List<TripRecord> findTripRecordListWithMemberInMemberIds(List<Long> memberIds) {
+        QTripRecord tripRecord = QTripRecord.tripRecord;
+        QMember member = QMember.member;
+
+        return queryFactory.selectFrom(tripRecord)
+            .join(tripRecord.member, member).fetchJoin()
+            .where(member.id.in(memberIds))
+            .orderBy(tripRecord.storeCount.desc(), tripRecord.createdAt.desc())
+            .fetch();
+    }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
@@ -167,7 +167,7 @@ public class TripRecordCustomRepositoryImpl extends QuerydslRepositorySupport im
                     .where(qTripRecordScheduleVideo.tripRecordSchedule.tripRecord.id.eq(qTripRecord.id)),
                 Projections.constructor(TripRecordMemberResponseDto.class,
                     qMember.memberBase.nickname,
-                    qMember.profile_image)))
+                    qMember.profileImage)))
             .from(qTripRecord)
             .leftJoin(qTripRecord.tripRecordSchedules, qTripRecordSchedule)
             .leftJoin(qTripRecordSchedule.tripRecordScheduleVideos, qTripRecordScheduleVideo)

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_video;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.query.NewestTripRecordScheduleVideoQueryDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.query.TripRecordScheduleVideoQueryDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordScheduleVideo;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -18,4 +19,6 @@ public interface TripRecordScheduleVideoRepositoryCustom {
     List<NewestTripRecordScheduleVideoQueryDto> findNewestVideoListDomestic(int size);
 
     List<NewestTripRecordScheduleVideoQueryDto> findNewestVideoListOverseas(int size);
+
+    List<TripRecordScheduleVideoQueryDto> findVideoListInMemberIds(List<Long> memberIds);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_video;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.query.NewestTripRecordScheduleVideoQueryDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.query.TripRecordScheduleVideoQueryDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecordScheduleVideo;
 import com.haejwo.tripcometrue.global.enums.Country;
 import com.querydsl.core.types.Order;
@@ -139,6 +140,30 @@ public class TripRecordScheduleVideoRepositoryImpl implements TripRecordSchedule
             .where(tripRecord.countries.containsIgnoreCase(Country.KOREA.name()).not())
             .orderBy(tripRecordScheduleVideo.createdAt.desc())
             .limit(size)
+            .fetch();
+    }
+
+    @Override
+    public List<TripRecordScheduleVideoQueryDto> findVideoListInMemberIds(List<Long> memberIds) {
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    TripRecordScheduleVideoQueryDto.class,
+                    tripRecordScheduleVideo.id,
+                    tripRecord.id,
+                    tripRecord.title,
+                    tripRecordScheduleVideo.thumbnailUrl,
+                    tripRecordScheduleVideo.videoUrl,
+                    tripRecord.storeCount,
+                    member.id
+                )
+            )
+            .from(tripRecordScheduleVideo)
+            .join(tripRecordScheduleVideo.tripRecordSchedule, tripRecordSchedule)
+            .join(tripRecordSchedule.tripRecord, tripRecord)
+            .join(tripRecord.member, member)
+            .where(member.id.in(memberIds))
+            .orderBy(tripRecordScheduleVideo.createdAt.desc())
             .fetch();
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordScheduleVideoService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordScheduleVideoService.java
@@ -2,11 +2,12 @@ package com.haejwo.tripcometrue.domain.triprecord.service;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.query.NewestTripRecordScheduleVideoQueryDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media.NewestTripRecordScheduleVideoResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media.TripRecordScheduleVideoListItemResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_video.TripRecordScheduleVideoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -17,8 +18,11 @@ public class TripRecordScheduleVideoService {
 
     private static final int HOME_CONTENT_SIZE = 5;
 
+    @Transactional(readOnly = true)
     public List<NewestTripRecordScheduleVideoResponseDto> getNewestVideos(String type) {
-        List<NewestTripRecordScheduleVideoQueryDto> queryResults = new ArrayList<>();
+
+        List<NewestTripRecordScheduleVideoQueryDto> queryResults;
+
         if (type.equalsIgnoreCase("all")) {
             queryResults = tripRecordScheduleVideoRepository.findNewestVideoList(HOME_CONTENT_SIZE);
         } else if (type.equalsIgnoreCase("domestic")) {
@@ -29,6 +33,16 @@ public class TripRecordScheduleVideoService {
 
         return queryResults.stream()
             .map(NewestTripRecordScheduleVideoResponseDto::fromQueryDto)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TripRecordScheduleVideoListItemResponseDto> getVideosInMemberIds(List<Long> memberIds) {
+
+        return tripRecordScheduleVideoRepository
+            .findVideoListInMemberIds(memberIds)
+            .stream()
+            .map(TripRecordScheduleVideoListItemResponseDto::fromQueryDto)
             .toList();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -16,14 +16,15 @@ import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule_
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_viewcount.TripRecordViewCountRepository;
 import com.haejwo.tripcometrue.domain.triprecordViewHistory.service.TripRecordViewHistoryService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -86,6 +87,26 @@ public class TripRecordService {
                 .map(TopTripRecordResponseDto::fromEntity)
                 .toList();
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<TripRecordListItemResponseDto> findTripRecordsInMemberIds(List<Long> memberIds) {
+
+        return tripRecordRepository
+            .findTripRecordListInMemberIds(memberIds)
+            .stream()
+            .map(TripRecordListItemResponseDto::fromEntity)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TripRecordListItemWithMemberIdResponseDto> findTripRecordsWihMemberInMemberIds(List<Long> memberIds) {
+
+        return tripRecordRepository
+            .findTripRecordListWithMemberInMemberIds(memberIds)
+            .stream()
+            .map(TripRecordListItemWithMemberIdResponseDto::fromEntity)
+            .toList();
     }
 
     @Transactional

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -1,9 +1,7 @@
 package com.haejwo.tripcometrue.domain.triprecord.service;
 
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.ModelAttribute.TripRecordListRequestAttribute;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TopTripRecordResponseDto;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.*;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media.TripRecordHotShortsListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media.TripRecordScheduleVideoDetailDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;

--- a/src/main/java/com/haejwo/tripcometrue/global/util/SliceResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/util/SliceResponseDto.java
@@ -1,13 +1,13 @@
-package com.haejwo.tripcometrue.domain.city.dto.response;
+package com.haejwo.tripcometrue.global.util;
 
 import lombok.Builder;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
-public record SliceResponse<T>(
+public record SliceResponseDto<T>(
     List<T> content,
-    SortResponse sort,
+    SortResponseDto sort,
     Integer totalCount,
     Integer currentPageNum,
     Integer pageSize,
@@ -16,13 +16,13 @@ public record SliceResponse<T>(
 ) {
 
     @Builder
-    public SliceResponse {
+    public SliceResponseDto {
     }
 
-    public static <T> SliceResponse<T> of(Slice<T> slice) {
-        return SliceResponse.<T>builder()
+    public static <T> SliceResponseDto<T> of(Slice<T> slice) {
+        return SliceResponseDto.<T>builder()
             .content(slice.getContent())
-            .sort(SortResponse.of(slice.getSort()))
+            .sort(SortResponseDto.of(slice.getSort()))
             .totalCount(slice.getNumberOfElements())
             .currentPageNum(slice.getNumber())
             .pageSize(slice.getSize())

--- a/src/main/java/com/haejwo/tripcometrue/global/util/SortResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/util/SortResponseDto.java
@@ -1,24 +1,24 @@
-package com.haejwo.tripcometrue.domain.city.dto.response;
+package com.haejwo.tripcometrue.global.util;
 
 import lombok.Builder;
 import org.springframework.data.domain.Sort;
 
 import java.util.Objects;
 
-public record SortResponse(
+public record SortResponseDto(
     Boolean sorted,
     String direction,
     String orderProperty
 ) {
 
     @Builder
-    public SortResponse {
+    public SortResponseDto {
     }
 
-    public static SortResponse of(Sort sort) {
+    public static SortResponseDto of(Sort sort) {
         Sort.Order order = sort.get().findFirst().orElse(null);
 
-        return SortResponse.builder()
+        return SortResponseDto.builder()
             .sorted(sort.isSorted())
             .direction(Objects.nonNull(order) ? order.getDirection().name() : null)
             .orderProperty(Objects.nonNull(order) ? order.getProperty() : null)

--- a/src/test/java/com/haejwo/tripcometrue/config/DatabaseCleanUpAfterEach.java
+++ b/src/test/java/com/haejwo/tripcometrue/config/DatabaseCleanUpAfterEach.java
@@ -1,0 +1,14 @@
+package com.haejwo.tripcometrue.config;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DatabaseCleanerExtension.class)
+public @interface DatabaseCleanUpAfterEach {
+}

--- a/src/test/java/com/haejwo/tripcometrue/config/DatabaseCleanerExtension.java
+++ b/src/test/java/com/haejwo/tripcometrue/config/DatabaseCleanerExtension.java
@@ -1,0 +1,51 @@
+package com.haejwo.tripcometrue.config;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+public class DatabaseCleanerExtension implements AfterEachCallback {
+
+    @Override
+    @Transactional
+    public void afterEach(ExtensionContext context) throws Exception {
+        var applicationContext = SpringExtension.getApplicationContext(context);
+        var jdbcTemplate = applicationContext.getBean(JdbcTemplate.class);
+
+        try (var connection = Objects.requireNonNull(Objects.requireNonNull(jdbcTemplate.getDataSource()).getConnection())) {
+            var rs = connection.getMetaData().getTables(null, null, "%", new String[]{"TABLE"});
+
+            executeResetTableQuery(jdbcTemplate, rs);
+
+        } catch (Exception exception) {
+            throw new RuntimeException("database table clean error");
+        }
+    }
+
+    private void executeResetTableQuery(JdbcTemplate jdbcTemplate, ResultSet rs) throws SQLException {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+        while (rs.next()) {
+            var tableName = rs.getString("TABLE_NAME");
+            jdbcTemplate.execute(createTruncateTableQuery(tableName));
+            jdbcTemplate.execute(createResetAutoIncrementQuery(tableName));
+        }
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+    }
+
+    private String createTruncateTableQuery(String tableName) {
+        return "TRUNCATE TABLE " + tableName;
+    }
+
+    private String createResetAutoIncrementQuery(String tableName) {
+        return "ALTER TABLE " + tableName + " AUTO_INCREMENT = 1";
+    }
+
+}

--- a/src/test/java/com/haejwo/tripcometrue/domain/city/repository/WeatherRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/city/repository/WeatherRepositoryTest.java
@@ -12,11 +12,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("test")
 @Import(TestQuerydslConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest

--- a/src/test/java/com/haejwo/tripcometrue/domain/city/service/CityInfoReadServiceTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/city/service/CityInfoReadServiceTest.java
@@ -1,6 +1,7 @@
 package com.haejwo.tripcometrue.domain.city.service;
 
 import com.haejwo.tripcometrue.config.AbstractContainersSupport;
+import com.haejwo.tripcometrue.config.DatabaseCleanUpAfterEach;
 import com.haejwo.tripcometrue.domain.city.dto.response.CityInfoResponseDto;
 import com.haejwo.tripcometrue.domain.city.dto.response.WeatherResponseDto;
 import com.haejwo.tripcometrue.domain.city.entity.City;
@@ -13,7 +14,6 @@ import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
 import com.haejwo.tripcometrue.global.enums.Country;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,9 +21,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
+@DatabaseCleanUpAfterEach
 @SpringBootTest
 class CityInfoReadServiceTest extends AbstractContainersSupport {
 
@@ -125,13 +127,5 @@ class CityInfoReadServiceTest extends AbstractContainersSupport {
         // when & then
         assertThatThrownBy(() -> cityInfoReadService.getWeatherInfo(cityId))
             .isInstanceOf(CityNotFoundException.class);
-    }
-
-    @AfterEach
-    void cleanUp() {
-        log.info("cleanUp 실행");
-        weatherRepository.deleteAll();
-        placeRepository.deleteAll();
-        cityRepository.deleteAll();
     }
 }

--- a/src/test/java/com/haejwo/tripcometrue/domain/member/facade/MemberSearchFacadeTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/member/facade/MemberSearchFacadeTest.java
@@ -1,0 +1,74 @@
+package com.haejwo.tripcometrue.domain.member.facade;
+
+import com.haejwo.tripcometrue.config.AbstractContainersSupport;
+import com.haejwo.tripcometrue.config.DatabaseCleanUpAfterEach;
+import com.haejwo.tripcometrue.domain.member.dto.response.MemberDetailListItemResponseDto;
+import com.haejwo.tripcometrue.domain.member.dto.response.MemberSearchResultWithContentResponseDto;
+import com.haejwo.tripcometrue.global.util.SliceResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@DatabaseCleanUpAfterEach
+@Sql(scripts = "classpath:sql/test-data-insert.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@SpringBootTest
+class MemberSearchFacadeTest extends AbstractContainersSupport {
+
+    @Autowired
+    private MemberSearchFacade memberSearchFacade;
+
+    @Test
+    void searchByNicknameResultWithContent() {
+        // given
+        String query = "치 앙마이";
+
+        // when
+        MemberSearchResultWithContentResponseDto result = memberSearchFacade.searchByNicknameResultWithContent(query);
+
+        // then
+        assertThat(result.members()).hasSize(2);
+        assertThat(result.tripRecords()).hasSize(3);
+        assertThat(result.videos()).hasSize(5);
+    }
+
+    @Test
+    void searchByNicknamePagination() {
+        // given
+        String query = "치 앙마이";
+        int pageNum = 0;
+        int pageSize = 1;
+        PageRequest pageRequest = PageRequest.of(pageNum, pageSize, Sort.by(Sort.Direction.DESC, "memberRating"));
+
+        // when
+        SliceResponseDto<MemberDetailListItemResponseDto> result = memberSearchFacade.searchByNicknamePagination(query, pageRequest);
+
+        // then
+        assertThat(result.currentPageNum()).isEqualTo(pageNum);
+        assertThat(result.totalCount()).isEqualTo(pageSize);
+        assertThat(result.last()).isFalse();
+    }
+
+    @Test
+    void searchByNicknamePagination_emptyResult() {
+        // given
+        String query = "없습니다.";
+        int pageNum = 0;
+        int pageSize = 1;
+        PageRequest pageRequest = PageRequest.of(pageNum, pageSize, Sort.by(Sort.Direction.DESC, "memberRating"));
+
+        // when
+        SliceResponseDto<MemberDetailListItemResponseDto> result = memberSearchFacade.searchByNicknamePagination(query, pageRequest);
+
+        // then
+        assertThat(result.currentPageNum()).isEqualTo(pageNum);
+        assertThat(result.totalCount()).isEqualTo(0);
+        assertThat(result.last()).isTrue();
+    }
+}

--- a/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_image/TripRecordScheduleImageRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_image/TripRecordScheduleImageRepositoryTest.java
@@ -18,7 +18,6 @@ import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord.TripRecor
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule.TripRecordScheduleRepository;
 import com.haejwo.tripcometrue.global.enums.Country;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +27,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +35,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
+@ActiveProfiles("test")
 @Import(TestQuerydslConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
@@ -149,7 +150,7 @@ class TripRecordScheduleImageRepositoryTest {
 
         TripRecord tripRecord1 = tripRecordRepository.save(
             TripRecord.builder()
-                .averageRating(4)
+                .averageRating(4.0)
                 .title("여행 후기 제목")
                 .content("여행 후기")
                 .countries("프랑스,영국")
@@ -168,7 +169,7 @@ class TripRecordScheduleImageRepositoryTest {
 
         TripRecord tripRecord2 = tripRecordRepository.save(
             TripRecord.builder()
-                .averageRating(4)
+                .averageRating(4.0)
                 .title("여행 후기 제목")
                 .content("여행 후기")
                 .countries("일본")
@@ -187,7 +188,7 @@ class TripRecordScheduleImageRepositoryTest {
 
         TripRecord tripRecord3 = tripRecordRepository.save(
             TripRecord.builder()
-                .averageRating(4)
+                .averageRating(4.0)
                 .title("여행 후기 제목")
                 .content("여행 후기")
                 .countries("태국")
@@ -361,15 +362,5 @@ class TripRecordScheduleImageRepositoryTest {
 
         // then
         assertThat(result).hasSize(7);
-    }
-
-    @AfterEach
-    void cleanUp() {
-        tripRecordScheduleImageRepository.deleteAll();
-        tripRecordScheduleRepository.deleteAll();
-        tripRecordRepository.deleteAll();
-        memberRepository.deleteAll();
-        placeRepository.deleteAll();
-        cityRepository.deleteAll();
     }
 }

--- a/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
@@ -18,20 +18,21 @@ import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord.TripRecor
 import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule.TripRecordScheduleRepository;
 import com.haejwo.tripcometrue.global.enums.Country;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
+@ActiveProfiles("test")
 @Import(TestQuerydslConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest
@@ -143,7 +144,7 @@ class TripRecordScheduleVideoRepositoryTest {
 
         TripRecord tripRecord1 = tripRecordRepository.save(
             TripRecord.builder()
-                .averageRating(4)
+                .averageRating(4.0)
                 .title("여행 후기 제목")
                 .content("여행 후기")
                 .countries("THAILAND")
@@ -162,7 +163,7 @@ class TripRecordScheduleVideoRepositoryTest {
 
         TripRecord tripRecord2 = tripRecordRepository.save(
             TripRecord.builder()
-                .averageRating(4)
+                .averageRating(4.0)
                 .title("여행 후기 제목")
                 .content("여행 후기")
                 .countries("JAPAN")
@@ -181,7 +182,7 @@ class TripRecordScheduleVideoRepositoryTest {
 
         TripRecord tripRecord3 = tripRecordRepository.save(
             TripRecord.builder()
-                .averageRating(4)
+                .averageRating(4.0)
                 .title("여행 후기 제목")
                 .content("여행 후기")
                 .countries("KOREA")
@@ -325,15 +326,5 @@ class TripRecordScheduleVideoRepositoryTest {
 
         //then
         assertThat(result).hasSize(4);
-    }
-
-    @AfterEach
-    void cleanUp() {
-        tripRecordScheduleVideoRepository.deleteAll();
-        tripRecordScheduleRepository.deleteAll();
-        tripRecordRepository.deleteAll();
-        memberRepository.deleteAll();
-        placeRepository.deleteAll();
-        cityRepository.deleteAll();
     }
 }

--- a/src/test/resources/sql/test-data-insert.sql
+++ b/src/test/resources/sql/test-data-insert.sql
@@ -1,0 +1,92 @@
+/* member */
+insert into member (member_id, created_at, updated_at, authority, email, nickname, password, member_rating, profile_image, introduction)
+values (1, now(), now(), 'ROLE_USER', 'member1@email.com', '치앙마이', 'password1', 4.0, 'profile image url', '치앙마이 소개글');
+
+insert into member (member_id, created_at, updated_at, authority, email, nickname, password, member_rating, profile_image, introduction)
+values (2, now(), now(), 'ROLE_USER', 'member2@email.com', '치앙 마이 러버', 'password2', 2.8, 'profile image url', '치앙 마이 러버 소개글');
+
+insert into member (member_id, created_at, updated_at, authority, email, nickname, password, member_rating, profile_image, introduction)
+values (3, now(), now(), 'ROLE_USER', 'member3@email.com', '파리지앵', 'password3', 4.3, 'profile image url', '파리지앵 소개글');
+
+/* city */
+insert into city (city_id, created_at, updated_at, country, currency, language, name, time_difference, visa, voltage,
+                  weather_description, weather_recommendation, image_url, store_count)
+values (1, now(), now(), 'THAILAND', 'THB', '태국어', '방콕', '2시간 느림', '90일 무비자 체류', '220V', '방콕 날씨 설명', '방콕 날씨 추천', '방콕 이미지', 45);
+
+insert into city (city_id, created_at, updated_at, country, currency, language, name, time_difference, visa, voltage,
+                  weather_description, weather_recommendation, image_url, store_count)
+values (2, now(), now(), 'JAPAN', 'JPY', '일본어', '도쿄', '시차 없음', '90일 무비자 체류', '220V', '도쿄 날씨 설명', '도쿄 날씨 추천', '도쿄 이미지', 100);
+
+insert into city (city_id, created_at, updated_at, country, currency, language, name, time_difference, visa, voltage,
+                  weather_description, weather_recommendation, image_url, store_count)
+values (3, now(), now(), 'USA', 'USD', '영어', '뉴욕', '14시간 느림', '90일 무비자 체류', '110V', '뉴욕 날씨 설명', '뉴욕 날씨 추천', '뉴욕 이미지', 95);
+
+insert into city (city_id, created_at, updated_at, country, language, name, weather_description, weather_recommendation, image_url, store_count)
+values (4, now(), now(), 'KOREA', '한국어', '부산', '부산 날씨 설명', '부산 날씨 추천', '부산 이미지', 88);
+
+/* place */
+insert into place (place_id, created_at, updated_at, address, city_id, description, name, stored_count, latitude, longitude, comment_count, review_count)
+values (1, now(), now(), '여행지1 주소', 1, '여행지1 설명', '여행지1', 30, 130.7, 45.6, 10, 10);
+
+insert into place (place_id, created_at, updated_at, address, city_id, description, name, stored_count, latitude, longitude, comment_count, review_count)
+values (2, now(), now(), '여행지2 주소', 2, '여행지2 설명', '여행지2', 45, 130.7, 45.6, 20, 10);
+
+insert into place (place_id, created_at, updated_at, address, city_id, description, name, stored_count, latitude, longitude, comment_count, review_count)
+values (3, now(), now(), '여행지3 주소', 3, '여행지3 설명', '여행지3', 100, 130.7, 45.6, 15, 10);
+
+insert into place (place_id, created_at, updated_at, address, city_id, description, name, stored_count, latitude, longitude, comment_count, review_count)
+values (4, now(), now(), '여행지4 주소', 4, '여행지4 설명', '여행지4', 20, 130.7, 45.6, 33, 10);
+
+
+/* trip_record */
+insert into trip_record (trip_record_id, average_rating, content, countries, expense_range_type, title, total_days, trip_end_day, trip_start_day, view_count,
+                         created_at, updated_at, member_id, comment_count, review_count, store_count)
+values (1, 3.5, '여행 컨텐츠1', 'THAILAND', 'BELOW_100', '방콕 여행 제목', 4, '2024-01-25', '2024-01-22', 100, now(), now(), 1, 5, 3, 30);
+
+insert into trip_record (trip_record_id, average_rating, content, countries, expense_range_type, title, total_days, trip_end_day, trip_start_day, view_count,
+                         created_at, updated_at, member_id, comment_count, review_count, store_count)
+values (2, 4.1, '여행 컨텐츠2', 'JAPAN', 'BELOW_200', '도쿄 여행 제목', 4, '2024-01-25', '2024-01-22', 100, now(), now(), 1, 5, 3, 50);
+
+insert into trip_record (trip_record_id, average_rating, content, countries, expense_range_type, title, total_days, trip_end_day, trip_start_day, view_count,
+                         created_at, updated_at, member_id, comment_count, review_count, store_count)
+values (3, 2.9, '여행 컨텐츠3', 'KOREA', 'BELOW_50', '부산 여행 제목', 2, '2024-01-30', '2024-01-29', 200, now(), now(), 2, 5, 3, 45);
+
+insert into trip_record (trip_record_id, average_rating, content, countries, expense_range_type, title, total_days, trip_end_day, trip_start_day, view_count,
+                         created_at, updated_at, member_id, comment_count, review_count, store_count)
+values (4, 2.9, '여행 컨텐츠4', 'USA', 'BELOW_300', '뉴욕 여행 제목', 10, '2024-02-01', '2024-02-10', 400, now(), now(), 3, 5, 3, 70);
+
+
+/* trip_record_schedule */
+insert into trip_record_schedule (trip_record_schedule_id, content, day_number, ordering, trip_record_id, created_at, updated_at, place_id)
+values (1, '여행 스케줄1', 1, 1, 1, now(), now(), 1);
+
+insert into trip_record_schedule (trip_record_schedule_id, content, day_number, ordering, trip_record_id, created_at, updated_at, place_id)
+values (2, '여행 스케줄2', 1, 2, 1, now(), now(), 1);
+
+insert into trip_record_schedule (trip_record_schedule_id, content, day_number, ordering, trip_record_id, created_at, updated_at, place_id)
+values (3, '여행 스케줄3', 1, 1, 2, now(), now(), 2);
+
+insert into trip_record_schedule (trip_record_schedule_id, content, day_number, ordering, trip_record_id, created_at, updated_at, place_id)
+values (4, '여행 스케줄4', 1, 1, 3, now(), now(), 3);
+
+insert into trip_record_schedule (trip_record_schedule_id, content, day_number, ordering, trip_record_id, created_at, updated_at, place_id)
+values (5, '여행 스케줄5', 1, 1, 4, now(), now(), 4);
+
+/* trip_record_schedule_video */
+insert into trip_record_schedule_video (trip_record_schedule_video_id, created_at, updated_at, video_url, trip_schedule_id, thumbnail_url)
+values (1, now(), now(), '쇼츠1', 1, '쇼츠1 썸네일');
+
+insert into trip_record_schedule_video (trip_record_schedule_video_id, created_at, updated_at, video_url, trip_schedule_id, thumbnail_url)
+values (2, now(), now(), '쇼츠2', 2, '쇼츠2 썸네일');
+
+insert into trip_record_schedule_video (trip_record_schedule_video_id, created_at, updated_at, video_url, trip_schedule_id, thumbnail_url)
+values (3, now(), now(), '쇼츠3', 3, '쇼츠3 썸네일');
+
+insert into trip_record_schedule_video (trip_record_schedule_video_id, created_at, updated_at, video_url, trip_schedule_id, thumbnail_url)
+values (4, now(), now(), '쇼츠4', 4, '쇼츠4 썸네일');
+
+insert into trip_record_schedule_video (trip_record_schedule_video_id, created_at, updated_at, video_url, trip_schedule_id, thumbnail_url)
+values (5, now(), now(), '쇼츠5', 5, '쇼츠5 썸네일');
+
+insert into trip_record_schedule_video (trip_record_schedule_video_id, created_at, updated_at, video_url, trip_schedule_id, thumbnail_url)
+values (6, now(), now(), '쇼츠6', 1, '쇼츠6 썸네일');


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)

- **간략한 설명**:
  : 홈 피드 2차 구현 작업 브랜치입니다.
   - 홈 크리에이터 검색 / 페이징 조회
   - 도시 검색 리스트 조회

---

## 🛠 작성/변경 사항

- **변경사항**
   - Member 엔티티에 memberRating(회원 평점) 타입을 Integer에서 Double로 변경했습니다.
   - Member 엔티티에 Snake Case로 되어 있는 필드를 모두 Camel Case로 변경했습니다.
---

## 🔗 관련 이슈

- **이슈 링크** : #89 

---

## 🧪 테스트

- 테스트 config 패키지에 `@DatabaseCleanUpAfterEach` 애노테이션 추가 + AfterEachCallback을 구현한 DatabaseCleanerExtension 클래스를 추가했습니다.
   - 클래스나 메서드에  `@DatabaseCleanUpAfterEach`를 추가하면 `@AfterEach`가 실행되며 모든 테이블의 데이터를 날리고
   모든 테이블의 Auto Increment id를 1로 초기화하는 작업을 수행합니다.

This close #89 
