### PR TITLE
[fix] 여행 후기를 여행 계획으로 복사해 오는 로직 수정, 여행 계획 작성 시 body값 수정, generateName 함수 수정

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/member/service/MemberService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/member/service/MemberService.java
@@ -57,10 +57,10 @@ public class MemberService {
     public String generateName() {
         List<String> first = Arrays.asList("자유로운", "서운한",
             "당당한", "배부른", "수줍은", "멋있는",
-            "열받은", "심심한", "잘생긴", "이쁜", "시끄러운");
+            "용기있는", "심심한", "잘생긴", "이쁜", "눈웃음치는", "행복한", "사랑스러운", "순수한");
         List<String> name = Arrays.asList("사자", "코끼리", "호랑이", "곰", "여우", "늑대", "너구리",
-            "참새", "고슴도치", "강아지", "고양이", "거북이", "토끼", "앵무새", "하이에나", "돼지", "하마",
-            "얼룩말", "치타", "악어", "기린", "수달", "염소", "다람쥐", "판다");
+            "참새", "고슴도치", "강아지", "고양이", "거북이", "토끼", "앵무새", "하이에나", "펭귄", "하마",
+            "얼룩말", "치타", "악어", "기린", "수달", "염소", "다람쥐", "판다", "코알라", "앵무새", "독수리", "알파카");
         Collections.shuffle(first);
         Collections.shuffle(name);
         return first.get(0) + name.get(0);
@@ -80,7 +80,7 @@ public class MemberService {
 
         //새비밀번호 재입력값 동일여부 최종 검증
         if (!passwordRequestDto.newPassword().equals(passwordRequestDto.confirmPassword())) {
-                throw new NewPasswordNotMatchException();
+            throw new NewPasswordNotMatchException();
         }
 
         String encodedNewPassword = passwordEncoder.encode(newPassword);
@@ -96,14 +96,16 @@ public class MemberService {
         String newPassword = passwordRequestDto.newPassword();
 
         // 현재 비밀번호만 입력된 경우
-        if (passwordRequestDto.currentPassword() != null && passwordRequestDto.newPassword() == null) {
+        if (passwordRequestDto.currentPassword() != null
+            && passwordRequestDto.newPassword() == null) {
             if (!passwordEncoder.matches(passwordRequestDto.currentPassword(), currentPassword)) {
                 throw new CurrentPasswordNotMatchException();
             }
         }
 
         // 새 비밀번호만 입력된 경우
-        if (passwordRequestDto.newPassword() != null && passwordRequestDto.currentPassword() == null) {
+        if (passwordRequestDto.newPassword() != null
+            && passwordRequestDto.currentPassword() == null) {
             if (passwordEncoder.matches(passwordRequestDto.newPassword(), currentPassword)) {
                 throw new NewPasswordSameAsOldException();
             }
@@ -142,7 +144,9 @@ public class MemberService {
     public NicknameResponseDto updateNickname(
         PrincipalDetails principalDetails, NicknameRequestDto requestDto) {
         memberRepository.findByMemberBaseNickname(requestDto.nickname())
-            .ifPresent(existingMember -> {throw new NicknameAlreadyExistsException();});
+            .ifPresent(existingMember -> {
+                throw new NicknameAlreadyExistsException();
+            });
         Member member = getLoginMember(principalDetails);
         member.getMemberBase().changeNickname(requestDto.nickname());
         member.updateNickNameChangeCount();
@@ -158,7 +162,7 @@ public class MemberService {
         memberRepository.delete(member);
     }
 
-    public Member getLoginMember(PrincipalDetails principalDetails){
+    public Member getLoginMember(PrincipalDetails principalDetails) {
         Member member = memberRepository.findById(principalDetails.getMember().getId())
             .orElseThrow();
         return member;

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/controller/TripPlanController.java
@@ -82,7 +82,7 @@ public class TripPlanController {
             .body(responseBody);
     }
 
-    @PostMapping("from-trip-record/{tripRecordId}")
+    @GetMapping("from-trip-record/{tripRecordId}")
     public ResponseEntity<ResponseDTO<CopyTripPlanFromTripRecordResponseDto>> copyTripPlanFromTripRecord(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @PathVariable Long tripRecordId) {

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/request/TripPlanRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/dto/request/TripPlanRequestDto.java
@@ -17,6 +17,7 @@ public record TripPlanRequestDto(
     @NotNull(message = "tripEndDay은 필수값입니다")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     LocalDate tripEndDay,
+    Long referencedBy,
     List<TripPlanScheduleRequestDto> tripPlanSchedules
 ) {
 
@@ -26,6 +27,7 @@ public record TripPlanRequestDto(
             .tripStartDay(this.tripStartDay)
             .tripEndDay(this.tripEndDay)
             .member(member)
+            .referencedBy(this.referencedBy)
             .build();
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/sevice/TripPlanService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/sevice/TripPlanService.java
@@ -4,13 +4,12 @@ import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.place.exception.PlaceNotFoundException;
 import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
 import com.haejwo.tripcometrue.domain.store.entity.TripRecordStore;
-import com.haejwo.tripcometrue.domain.store.repository.TripRecordStoreRepository;
 import com.haejwo.tripcometrue.domain.tripplan.dto.request.TripPlanRequestDto;
 import com.haejwo.tripcometrue.domain.tripplan.dto.request.TripPlanScheduleRequestDto;
 import com.haejwo.tripcometrue.domain.tripplan.dto.response.CopyTripPlanFromTripRecordResponseDto;
 import com.haejwo.tripcometrue.domain.tripplan.dto.response.TripPlanDetailsResponseDto;
-import com.haejwo.tripcometrue.domain.tripplan.dto.response.TripPlanScheduleResponseDto;
 import com.haejwo.tripcometrue.domain.tripplan.dto.response.TripPlanListReponseDto;
+import com.haejwo.tripcometrue.domain.tripplan.dto.response.TripPlanScheduleResponseDto;
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlan;
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlanSchedule;
 import com.haejwo.tripcometrue.domain.tripplan.exception.TripPlanNotFoundException;
@@ -36,7 +35,6 @@ public class TripPlanService {
     private final TripPlanRepository tripPlanRepository;
     private final TripPlanScheduleRepository tripPlanScheduleRepository;
     private final PlaceRepository placeRepository;
-    private final TripRecordStoreRepository tripRecordStoreRepository;
     private final TripRecordRepository tripRecordRepository;
     private final TripRecordScheduleRepository tripRecordScheduleRepository;
 
@@ -122,8 +120,6 @@ public class TripPlanService {
                 .orElseThrow(TripRecordNotFoundException::new))
             .build();
 
-        tripRecordStoreRepository.save(tripRecordStore);
-
         List<TripPlanScheduleResponseDto> responseDtos = tripRecordScheduleRepository
             .findAllByTripRecordId(tripRecordId)
             .stream()
@@ -154,5 +150,6 @@ public class TripPlanService {
                 .collect(Collectors.toList());
 
             return TripPlanListReponseDto.fromEntity(tripPlan, placesVisited);
-        });    }
+        });
+    }
 }

--- a/src/test/http/trip_plan/trip_plan.http
+++ b/src/test/http/trip_plan/trip_plan.http
@@ -65,5 +65,5 @@ Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci
 GET http://localhost:8080/v1/trip-plan/1
 
 ### 여행 계획 복사
-POST http://localhost:8080/v1/trip-plan/from-trip-record/1
-Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
+GET http://localhost:8080/v1/trip-plan/from-trip-record/1
+Authorization: token

--- a/src/test/http/trip_plan/trip_plan.http
+++ b/src/test/http/trip_plan/trip_plan.http
@@ -1,13 +1,14 @@
 
 ### 여행 계획 작성
 POST http://localhost:8080/v1/trip-plan
-Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
+Authorization: token
 Content-Type: application/json
 
 {
   "countries": "한국,일본",
   "tripStartDay": "2024-01-10",
   "tripEndDay": "2024-01-20",
+  "referencedBy":10,
   "tripPlanSchedules": [
     {
       "dayNumber": 1,
@@ -30,7 +31,7 @@ Content-Type: application/json
 
 ### 여행 계획 수정
 PUT http://localhost:8080/v1/trip-plan/1
-Authorization: eyJraWQiOiJrZXkzIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiJ0ZXN0MUBuYXZlci5jb20iLCJpYXQiOjE3MDUxNDE4NzksImV4cCI6MTcwNTI4NTg3OX0.WsPlvC_DJDnh4j3O0x6Di3SRc6FfqjnhRlgMFBOZkaI
+Authorization: token
 Content-Type: application/json
 
 {


### PR DESCRIPTION
## 🎯 목적

- [x] 리팩토링 (Refactoring)
- [x] 버그 수정 (Bug Fix)


- **간략한 설명**:
  : 여행 후기를 여행 계획으로 복사해 오는 로직 수정, 여행 계획 작성 시 body값 수정, generateName 함수 수정

---

## 🛠 작성/변경 사항

- **(주요작성/변경사항)**
- 여행 후기에서 여행 계획 조회하는 api http 메소드 변경 
- 후기 복사시 trip_record_store에 생성되는 로직 삭제 
- 여행계획 생성시 참조한 후기 id 입력할 수 있도록 body 추가 
- generateName 함수 수정 
---

## 🔗 관련 이슈

- **이슈 링크1** : #106