### PR TITLE
[feat] 여행지 리뷰 댓글, 대댓글(PlaceReviewComment) CRUD 기능 구현

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentController.java
@@ -51,14 +51,14 @@ public class PlaceReviewCommentController {
 //                commentService.getCommentList(principalDetails, tripRecordId, pageable);
 //        return ResponseEntity.ok(ResponseDTO.okWithData(responseDto));
 //    }
-//
-//    @DeleteMapping("/comments/{tripRecordCommentId}")
-//    public ResponseEntity<ResponseDTO<Void>> deleteComment(
-//            @AuthenticationPrincipal PrincipalDetails principalDetails,
-//            @PathVariable Long tripRecordCommentId
-//    ) {
-//
-//        commentService.removeComment(principalDetails, tripRecordCommentId);
-//        return ResponseEntity.ok(ResponseDTO.ok());
-//    }
+
+    @DeleteMapping("/comments/{placeReviewCommentId}")
+    public ResponseEntity<ResponseDTO<Void>> deleteComment(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable Long placeReviewCommentId
+    ) {
+
+        commentService.removeComment(principalDetails, placeReviewCommentId);
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentController.java
@@ -1,0 +1,69 @@
+package com.haejwo.tripcometrue.domain.comment.placereview.controller;
+
+import com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto;
+import com.haejwo.tripcometrue.domain.comment.placereview.service.PlaceReviewCommentService;
+import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.TripRecordCommentRequestDto;
+import com.haejwo.tripcometrue.domain.comment.triprecord.dto.response.TripRecordCommentListResponseDto;
+import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.data.domain.Sort.Direction;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/places/reviews")
+public class PlaceReviewCommentController {
+
+    private final PlaceReviewCommentService commentService;
+
+    @PostMapping("/{placeReviewId}/comments")
+    public ResponseEntity<ResponseDTO<Void>> registerComment(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable Long placeReviewId,
+            @RequestBody @Valid PlaceReviewCommentRequestDto requestDto
+    ) {
+
+        commentService.saveComment(principalDetails, placeReviewId, requestDto);
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
+
+//    @PostMapping("/comments/{tripRecordCommentId}/reply-comments")
+//    public ResponseEntity<ResponseDTO<Void>> registerReplyComment(
+//            @AuthenticationPrincipal PrincipalDetails principalDetails,
+//            @PathVariable Long tripRecordCommentId,
+//            @RequestBody @Valid TripRecordCommentRequestDto requestDto
+//    ) {
+//
+//        commentService.saveReplyComment(principalDetails, tripRecordCommentId, requestDto);
+//        return ResponseEntity.ok(ResponseDTO.ok());
+//    }
+//
+//    @GetMapping("/{tripRecordId}/comments")
+//    public ResponseEntity<ResponseDTO<TripRecordCommentListResponseDto>> getCommentList(
+//            @AuthenticationPrincipal PrincipalDetails principalDetails,
+//            @PathVariable Long tripRecordId,
+//            @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable
+//    ) {
+//
+//        TripRecordCommentListResponseDto responseDto =
+//                commentService.getCommentList(principalDetails, tripRecordId, pageable);
+//        return ResponseEntity.ok(ResponseDTO.okWithData(responseDto));
+//    }
+//
+//    @DeleteMapping("/comments/{tripRecordCommentId}")
+//    public ResponseEntity<ResponseDTO<Void>> deleteComment(
+//            @AuthenticationPrincipal PrincipalDetails principalDetails,
+//            @PathVariable Long tripRecordCommentId
+//    ) {
+//
+//        commentService.removeComment(principalDetails, tripRecordCommentId);
+//        return ResponseEntity.ok(ResponseDTO.ok());
+//    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentController.java
@@ -2,7 +2,6 @@ package com.haejwo.tripcometrue.domain.comment.placereview.controller;
 
 import com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto;
 import com.haejwo.tripcometrue.domain.comment.placereview.service.PlaceReviewCommentService;
-import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.TripRecordCommentRequestDto;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
 import jakarta.validation.Valid;
@@ -39,18 +38,6 @@ public class PlaceReviewCommentController {
         commentService.saveReplyComment(principalDetails, placeReviewCommentId, requestDto);
         return ResponseEntity.ok(ResponseDTO.ok());
     }
-//
-//    @GetMapping("/{tripRecordId}/comments")
-//    public ResponseEntity<ResponseDTO<TripRecordCommentListResponseDto>> getCommentList(
-//            @AuthenticationPrincipal PrincipalDetails principalDetails,
-//            @PathVariable Long tripRecordId,
-//            @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable
-//    ) {
-//
-//        TripRecordCommentListResponseDto responseDto =
-//                commentService.getCommentList(principalDetails, tripRecordId, pageable);
-//        return ResponseEntity.ok(ResponseDTO.okWithData(responseDto));
-//    }
 
     @DeleteMapping("/comments/{placeReviewCommentId}")
     public ResponseEntity<ResponseDTO<Void>> deleteComment(

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentController.java
@@ -3,18 +3,13 @@ package com.haejwo.tripcometrue.domain.comment.placereview.controller;
 import com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto;
 import com.haejwo.tripcometrue.domain.comment.placereview.service.PlaceReviewCommentService;
 import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.TripRecordCommentRequestDto;
-import com.haejwo.tripcometrue.domain.comment.triprecord.dto.response.TripRecordCommentListResponseDto;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import static org.springframework.data.domain.Sort.Direction;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,23 +22,23 @@ public class PlaceReviewCommentController {
     public ResponseEntity<ResponseDTO<Void>> registerComment(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long placeReviewId,
-            @RequestBody @Valid PlaceReviewCommentRequestDto requestDto
+            @RequestBody @Valid com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto requestDto
     ) {
 
         commentService.saveComment(principalDetails, placeReviewId, requestDto);
         return ResponseEntity.ok(ResponseDTO.ok());
     }
 
-//    @PostMapping("/comments/{tripRecordCommentId}/reply-comments")
-//    public ResponseEntity<ResponseDTO<Void>> registerReplyComment(
-//            @AuthenticationPrincipal PrincipalDetails principalDetails,
-//            @PathVariable Long tripRecordCommentId,
-//            @RequestBody @Valid TripRecordCommentRequestDto requestDto
-//    ) {
-//
-//        commentService.saveReplyComment(principalDetails, tripRecordCommentId, requestDto);
-//        return ResponseEntity.ok(ResponseDTO.ok());
-//    }
+    @PostMapping("/comments/{placeReviewCommentId}/reply-comments")
+    public ResponseEntity<ResponseDTO<Void>> registerReplyComment(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable Long placeReviewCommentId,
+            @RequestBody @Valid PlaceReviewCommentRequestDto requestDto
+    ) {
+
+        commentService.saveReplyComment(principalDetails, placeReviewCommentId, requestDto);
+        return ResponseEntity.ok(ResponseDTO.ok());
+    }
 //
 //    @GetMapping("/{tripRecordId}/comments")
 //    public ResponseEntity<ResponseDTO<TripRecordCommentListResponseDto>> getCommentList(

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentControllerAdvice.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/controller/PlaceReviewCommentControllerAdvice.java
@@ -1,0 +1,21 @@
+package com.haejwo.tripcometrue.domain.comment.placereview.controller;
+
+import com.haejwo.tripcometrue.domain.comment.placereview.exception.PlaceReviewCommentNotFoundException;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PlaceReviewCommentControllerAdvice {
+
+    @ExceptionHandler(PlaceReviewCommentNotFoundException.class)
+    public ResponseEntity<ResponseDTO<Void>> handlePlaceReviewCommentNotFoundException(PlaceReviewCommentNotFoundException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+
+        return ResponseEntity
+                .status(status)
+                .body(ResponseDTO.errorWithMessage(status, e.getMessage()));
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/dto/request/PlaceReviewCommentRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/dto/request/PlaceReviewCommentRequestDto.java
@@ -1,0 +1,39 @@
+package com.haejwo.tripcometrue.domain.comment.placereview.dto.request;
+
+import com.haejwo.tripcometrue.domain.comment.placereview.entity.PlaceReviewComment;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+
+public record PlaceReviewCommentRequestDto(
+
+        @NotNull(message = "본문은 필수로 입력해야 합니다.")
+        @Length(min = 1, max = 500, message = "작성 허용 범위는 최소 1자 또는 최대 500자 입니다.")
+        String content
+
+) {
+
+    public static PlaceReviewComment toComment(Member member, PlaceReview placeReview, PlaceReviewCommentRequestDto requestDto) {
+        return PlaceReviewComment.builder()
+                .member(member)
+                .placeReview(placeReview)
+                .content(requestDto.content)
+                .build();
+    }
+
+    public static PlaceReviewComment toReplyComment(
+            Member member,
+            PlaceReview placeReview,
+            PlaceReviewComment placeReviewComment,
+            PlaceReviewCommentRequestDto requestDto
+    ) {
+
+        return PlaceReviewComment.builder()
+                .member(member)
+                .placeReview(placeReview)
+                .parentComment(placeReviewComment)
+                .content(requestDto.content)
+                .build();
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/dto/response/PlaceReviewCommentListResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/dto/response/PlaceReviewCommentListResponseDto.java
@@ -1,0 +1,30 @@
+package com.haejwo.tripcometrue.domain.comment.placereview.dto.response;
+
+import com.haejwo.tripcometrue.domain.comment.placereview.entity.PlaceReviewComment;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.Objects;
+
+public record PlaceReviewCommentListResponseDto(
+
+        int totalCount,
+        List<PlaceReviewCommentResponseDto> comments
+
+) {
+
+    public static PlaceReviewCommentListResponseDto fromData(int totalCount, Slice<PlaceReviewComment> placeReviewComments, Member loginMember) {
+        return new PlaceReviewCommentListResponseDto(
+                totalCount,
+                placeReviewComments.map(placeReviewComment -> {
+                            if (placeReviewComment.getParentComment() == null) { //최상위 댓글만 포함
+                                return PlaceReviewCommentResponseDto.fromEntity(placeReviewComment, loginMember);
+                            }
+                            return null;
+                        })
+                        .filter(Objects::nonNull)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/dto/response/PlaceReviewCommentResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/dto/response/PlaceReviewCommentResponseDto.java
@@ -16,6 +16,7 @@ public record PlaceReviewCommentResponseDto(
         String profileUrl,
         String nickname,
         boolean isWriter,
+        String content,
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
         LocalDateTime createdAt,
@@ -31,6 +32,7 @@ public record PlaceReviewCommentResponseDto(
                 placeReviewComment.getMember().getProfileImage(),
                 placeReviewComment.getMember().getMemberBase().getNickname(),
                 isWriter(placeReviewComment, loginMember),
+                placeReviewComment.getContent(),
                 placeReviewComment.getCreatedAt(),
                 getReplyComments(placeReviewComment, loginMember) //자식 댓글 리스트에 담기
         );

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/dto/response/PlaceReviewCommentResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/dto/response/PlaceReviewCommentResponseDto.java
@@ -1,0 +1,52 @@
+package com.haejwo.tripcometrue.domain.comment.placereview.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.haejwo.tripcometrue.domain.comment.placereview.entity.PlaceReviewComment;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+public record PlaceReviewCommentResponseDto(
+
+        Long commentId,
+        Long memberId,
+        String profileUrl,
+        String nickname,
+        boolean isWriter,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
+        LocalDateTime createdAt,
+
+        List<PlaceReviewCommentResponseDto> replyComments
+
+) {
+
+    public static PlaceReviewCommentResponseDto fromEntity(PlaceReviewComment placeReviewComment, Member loginMember) {
+        return new PlaceReviewCommentResponseDto(
+                placeReviewComment.getId(),
+                placeReviewComment.getMember().getId(),
+                placeReviewComment.getMember().getProfileImage(),
+                placeReviewComment.getMember().getMemberBase().getNickname(),
+                isWriter(placeReviewComment, loginMember),
+                placeReviewComment.getCreatedAt(),
+                getReplyComments(placeReviewComment, loginMember) //자식 댓글 리스트에 담기
+        );
+    }
+
+    private static boolean isWriter(PlaceReviewComment placeReviewComment, Member loginMember) {
+        return Objects.equals(placeReviewComment.getMember(), loginMember);
+    }
+
+    private static List<PlaceReviewCommentResponseDto> getReplyComments(PlaceReviewComment placeReviewComment, Member loginMember) {
+        if (placeReviewComment.getParentComment() == null) {
+            return placeReviewComment.getChildComments().stream()
+                    .map(comment -> PlaceReviewCommentResponseDto.fromEntity(comment, loginMember))
+                    .sorted(Comparator.comparing(PlaceReviewCommentResponseDto::createdAt).reversed())
+                    .toList();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/entity/PlaceReviewComment.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/entity/PlaceReviewComment.java
@@ -1,0 +1,53 @@
+package com.haejwo.tripcometrue.domain.comment.placereview.entity;
+
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
+import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.FetchType.LAZY;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlaceReviewComment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "place_review_comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "place_review_id")
+    private PlaceReview placeReview;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private PlaceReviewComment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", cascade = REMOVE, orphanRemoval = true)
+    private List<PlaceReviewComment> childComments = new ArrayList<>();
+
+    @Column(nullable = false)
+    private String content;
+
+    @Builder
+    public PlaceReviewComment(Member member, PlaceReview placeReview, PlaceReviewComment parentComment, String content) {
+        this.member = member;
+        this.placeReview = placeReview;
+        this.parentComment = parentComment;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/exception/PlaceReviewCommentNotFoundException.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/exception/PlaceReviewCommentNotFoundException.java
@@ -1,0 +1,12 @@
+package com.haejwo.tripcometrue.domain.comment.placereview.exception;
+
+import com.haejwo.tripcometrue.global.exception.ApplicationException;
+import com.haejwo.tripcometrue.global.exception.ErrorCode;
+
+public class PlaceReviewCommentNotFoundException extends ApplicationException {
+    private static final ErrorCode ERROR_CODE = ErrorCode.PLACE_REVIEW_COMMENT_NOT_FOUND;
+
+    public PlaceReviewCommentNotFoundException() {
+        super(ERROR_CODE);
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/repository/PlaceReviewCommentRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/repository/PlaceReviewCommentRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface PlaceReviewCommentRepository extends JpaRepository<PlaceReviewComment, Long> {
 
-    Slice<PlaceReviewComment> findByPlaceReview(PlaceReview placeReview, Pageable pageable);
+    Slice<PlaceReviewComment> findByPlaceReviewOrderByCreatedAtDesc(PlaceReview placeReview, Pageable pageable);
 
     @Modifying
     @Query("delete from PlaceReviewComment prc where prc.parentComment.id = :placeReviewCommentId")

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/repository/PlaceReviewCommentRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/repository/PlaceReviewCommentRepository.java
@@ -1,0 +1,23 @@
+package com.haejwo.tripcometrue.domain.comment.placereview.repository;
+
+import com.haejwo.tripcometrue.domain.comment.placereview.entity.PlaceReviewComment;
+import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PlaceReviewCommentRepository extends JpaRepository<PlaceReviewComment, Long> {
+
+    Slice<PlaceReviewComment> findByPlaceReview(PlaceReview placeReview, Pageable pageable);
+
+    @Modifying
+    @Query("delete from PlaceReviewComment prc where prc.parentComment.id = :placeReviewCommentId")
+    int deleteChildrenByPlaceReviewCommentId(@Param("placeReviewCommentId") Long placeReviewCommentId);
+
+    @Modifying
+    @Query("delete from PlaceReviewComment prc where prc.id = :placeReviewCommentId")
+    int deleteParentByPlaceReviewCommentId(@Param("placeReviewCommentId") Long placeReviewCommentId);
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
@@ -1,0 +1,124 @@
+package com.haejwo.tripcometrue.domain.comment.placereview.service;
+
+import com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto;
+import com.haejwo.tripcometrue.domain.comment.placereview.entity.PlaceReviewComment;
+import com.haejwo.tripcometrue.domain.comment.placereview.repository.PlaceReviewCommentRepository;
+import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.TripRecordCommentRequestDto;
+import com.haejwo.tripcometrue.domain.comment.triprecord.dto.response.TripRecordCommentListResponseDto;
+import com.haejwo.tripcometrue.domain.comment.triprecord.entity.TripRecordComment;
+import com.haejwo.tripcometrue.domain.comment.triprecord.exception.TripRecordCommentNotFoundException;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.member.exception.UserInvalidAccessException;
+import com.haejwo.tripcometrue.domain.member.exception.UserNotFoundException;
+import com.haejwo.tripcometrue.domain.member.repository.MemberRepository;
+import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
+import com.haejwo.tripcometrue.domain.review.placereview.exception.PlaceReviewNotFoundException;
+import com.haejwo.tripcometrue.domain.review.placereview.repository.PlaceReviewRepository;
+import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
+import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlaceReviewCommentService {
+
+    private final MemberRepository memberRepository;
+    private final PlaceReviewRepository placeReviewRepository;
+    private final PlaceReviewCommentRepository placeReviewCommentRepository;
+
+    public void saveComment(
+            PrincipalDetails principalDetails,
+            Long placeReviewId,
+            PlaceReviewCommentRequestDto requestDto
+    ) {
+
+        Member loginMember = getMember(principalDetails);
+        PlaceReview placeReview = getPlaceReviewById(placeReviewId);
+
+        PlaceReviewComment comment = PlaceReviewCommentRequestDto.toComment(loginMember, placeReview, requestDto);
+        placeReviewCommentRepository.save(comment);
+        placeReview.increaseCommentCount();
+    }
+
+    private Member getMember(PrincipalDetails principalDetails) {
+        return memberRepository.findById(principalDetails.getMember().getId())
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    private PlaceReview getPlaceReviewById(Long placeReviewId) {
+        return placeReviewRepository.findById(placeReviewId)
+                .orElseThrow(PlaceReviewNotFoundException::new);
+    }
+
+//    public void saveReplyComment(
+//            PrincipalDetails principalDetails,
+//            Long tripRecordCommentId,
+//            TripRecordCommentRequestDto requestDto
+//    ) {
+//
+//        Member loginMember = getMember(principalDetails);
+//        TripRecordComment tripRecordComment = getTripRecordCommentById(tripRecordCommentId);
+//        TripRecord tripRecord = tripRecordComment.getTripRecord();
+//
+//        TripRecordComment comment = TripRecordCommentRequestDto.toReplyComment(loginMember, tripRecord, tripRecordComment, requestDto);
+//        tripRecordCommentRepository.save(comment);
+//        tripRecord.incrementCommentCount();
+//    }
+//
+//    private TripRecordComment getTripRecordCommentById(Long tripRecordCommentId) {
+//        return tripRecordCommentRepository.findById(tripRecordCommentId)
+//                .orElseThrow(TripRecordCommentNotFoundException::new);
+//    }
+//
+//    @Transactional(readOnly = true)
+//    public TripRecordCommentListResponseDto getCommentList(
+//            PrincipalDetails principalDetails,
+//            Long tripRecordId,
+//            Pageable pageable
+//    ) {
+//
+//        Member loginMember = getMember(principalDetails);
+//        TripRecord tripRecord = getPlaceReviewById(tripRecordId);
+//
+//        Slice<TripRecordComment> tripRecordComments = tripRecordCommentRepository.findByTripRecord(tripRecord, pageable);
+//        return TripRecordCommentListResponseDto.fromData(tripRecord.getCommentCount(), tripRecordComments, loginMember);
+//    }
+//
+//    public void removeComment(PrincipalDetails principalDetails, Long tripRecordCommentId) {
+//
+//        Member loginMember = getMember(principalDetails);
+//        TripRecordComment tripRecordComment = getTripRecordComment(tripRecordCommentId);
+//        TripRecord tripRecord = tripRecordComment.getTripRecord();
+//
+//        validateRightMemberAccess(loginMember, tripRecordComment);
+//
+//        int removedCount = getRemovedCount(tripRecordCommentId, tripRecordComment);
+//        tripRecord.decreaseCommentCount(removedCount);
+//    }
+//
+//    private int getRemovedCount(Long tripRecordCommentId, TripRecordComment tripRecordComment) {
+//        int childrenCount = tripRecordCommentRepository.deleteChildrenByTripRecordCommentId(tripRecordComment.getId());
+//        int parentCount = tripRecordCommentRepository.deleteParentByTripRecordCommentId(tripRecordCommentId);
+//        return childrenCount + parentCount;
+//    }
+//
+//    private TripRecordComment getTripRecordComment(Long tripRecordCommentId) {
+//        return tripRecordCommentRepository.findById(tripRecordCommentId)
+//                .orElseThrow(TripRecordCommentNotFoundException::new);
+//    }
+//
+//    private void validateRightMemberAccess(Member member, TripRecordComment tripRecordComment) {
+//        if (!Objects.equals(tripRecordComment.getMember().getId(), member.getId())) {
+//            throw new UserInvalidAccessException();
+//        }
+//    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
@@ -7,6 +7,7 @@ import com.haejwo.tripcometrue.domain.comment.placereview.repository.PlaceReview
 import com.haejwo.tripcometrue.domain.comment.triprecord.entity.TripRecordComment;
 import com.haejwo.tripcometrue.domain.comment.triprecord.exception.TripRecordCommentNotFoundException;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.domain.member.exception.UserInvalidAccessException;
 import com.haejwo.tripcometrue.domain.member.exception.UserNotFoundException;
 import com.haejwo.tripcometrue.domain.member.repository.MemberRepository;
 import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
@@ -17,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -67,8 +70,8 @@ public class PlaceReviewCommentService {
         placeReview.increaseCommentCount();
     }
 
-    private PlaceReviewComment getPlaceReviewCommentById(Long tripRecordCommentId) {
-        return placeReviewCommentRepository.findById(tripRecordCommentId)
+    private PlaceReviewComment getPlaceReviewCommentById(Long placeReviewCommentId) {
+        return placeReviewCommentRepository.findById(placeReviewCommentId)
                 .orElseThrow(PlaceReviewCommentNotFoundException::new);
     }
 //
@@ -85,33 +88,33 @@ public class PlaceReviewCommentService {
 //        Slice<TripRecordComment> tripRecordComments = tripRecordCommentRepository.findByTripRecord(tripRecord, pageable);
 //        return TripRecordCommentListResponseDto.fromData(tripRecord.getCommentCount(), tripRecordComments, loginMember);
 //    }
-//
-//    public void removeComment(PrincipalDetails principalDetails, Long tripRecordCommentId) {
-//
-//        Member loginMember = getMember(principalDetails);
-//        TripRecordComment tripRecordComment = getTripRecordComment(tripRecordCommentId);
-//        TripRecord tripRecord = tripRecordComment.getTripRecord();
-//
-//        validateRightMemberAccess(loginMember, tripRecordComment);
-//
-//        int removedCount = getRemovedCount(tripRecordCommentId, tripRecordComment);
-//        tripRecord.decreaseCommentCount(removedCount);
-//    }
-//
-//    private int getRemovedCount(Long tripRecordCommentId, TripRecordComment tripRecordComment) {
-//        int childrenCount = tripRecordCommentRepository.deleteChildrenByTripRecordCommentId(tripRecordComment.getId());
-//        int parentCount = tripRecordCommentRepository.deleteParentByTripRecordCommentId(tripRecordCommentId);
-//        return childrenCount + parentCount;
-//    }
-//
-//    private TripRecordComment getTripRecordComment(Long tripRecordCommentId) {
-//        return tripRecordCommentRepository.findById(tripRecordCommentId)
-//                .orElseThrow(TripRecordCommentNotFoundException::new);
-//    }
-//
-//    private void validateRightMemberAccess(Member member, TripRecordComment tripRecordComment) {
-//        if (!Objects.equals(tripRecordComment.getMember().getId(), member.getId())) {
-//            throw new UserInvalidAccessException();
-//        }
-//    }
+
+    public void removeComment(PrincipalDetails principalDetails, Long placeReviewCommentId) {
+
+        Member loginMember = getMember(principalDetails);
+        PlaceReviewComment placeReviewComment = getPlaceReviewComment(placeReviewCommentId);
+        PlaceReview placeReview = placeReviewComment.getPlaceReview();
+
+        validateRightMemberAccess(loginMember, placeReviewComment);
+
+        int removedCount = getRemovedCount(placeReviewCommentId, placeReviewComment);
+        placeReview.decreaseCommentCount(removedCount);
+    }
+
+    private PlaceReviewComment getPlaceReviewComment(Long placeReviewCommentId) {
+        return placeReviewCommentRepository.findById(placeReviewCommentId)
+                .orElseThrow(PlaceReviewCommentNotFoundException::new);
+    }
+
+    private int getRemovedCount(Long placeReviewCommentId, PlaceReviewComment placeReviewComment) {
+        int childrenCount = placeReviewCommentRepository.deleteChildrenByPlaceReviewCommentId(placeReviewComment.getId());
+        int parentCount = placeReviewCommentRepository.deleteParentByPlaceReviewCommentId(placeReviewCommentId);
+        return childrenCount + parentCount;
+    }
+
+    private void validateRightMemberAccess(Member member, PlaceReviewComment placeReviewComment) {
+        if (!Objects.equals(placeReviewComment.getMember().getId(), member.getId())) {
+            throw new UserInvalidAccessException();
+        }
+    }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
@@ -4,8 +4,6 @@ import com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceRevie
 import com.haejwo.tripcometrue.domain.comment.placereview.entity.PlaceReviewComment;
 import com.haejwo.tripcometrue.domain.comment.placereview.exception.PlaceReviewCommentNotFoundException;
 import com.haejwo.tripcometrue.domain.comment.placereview.repository.PlaceReviewCommentRepository;
-import com.haejwo.tripcometrue.domain.comment.triprecord.entity.TripRecordComment;
-import com.haejwo.tripcometrue.domain.comment.triprecord.exception.TripRecordCommentNotFoundException;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.member.exception.UserInvalidAccessException;
 import com.haejwo.tripcometrue.domain.member.exception.UserNotFoundException;
@@ -74,20 +72,6 @@ public class PlaceReviewCommentService {
         return placeReviewCommentRepository.findById(placeReviewCommentId)
                 .orElseThrow(PlaceReviewCommentNotFoundException::new);
     }
-//
-//    @Transactional(readOnly = true)
-//    public TripRecordCommentListResponseDto getCommentList(
-//            PrincipalDetails principalDetails,
-//            Long tripRecordId,
-//            Pageable pageable
-//    ) {
-//
-//        Member loginMember = getMember(principalDetails);
-//        TripRecord tripRecord = getPlaceReviewById(tripRecordId);
-//
-//        Slice<TripRecordComment> tripRecordComments = tripRecordCommentRepository.findByTripRecord(tripRecord, pageable);
-//        return TripRecordCommentListResponseDto.fromData(tripRecord.getCommentCount(), tripRecordComments, loginMember);
-//    }
 
     public void removeComment(PrincipalDetails principalDetails, Long placeReviewCommentId) {
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
@@ -2,28 +2,21 @@ package com.haejwo.tripcometrue.domain.comment.placereview.service;
 
 import com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto;
 import com.haejwo.tripcometrue.domain.comment.placereview.entity.PlaceReviewComment;
+import com.haejwo.tripcometrue.domain.comment.placereview.exception.PlaceReviewCommentNotFoundException;
 import com.haejwo.tripcometrue.domain.comment.placereview.repository.PlaceReviewCommentRepository;
-import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.TripRecordCommentRequestDto;
-import com.haejwo.tripcometrue.domain.comment.triprecord.dto.response.TripRecordCommentListResponseDto;
 import com.haejwo.tripcometrue.domain.comment.triprecord.entity.TripRecordComment;
 import com.haejwo.tripcometrue.domain.comment.triprecord.exception.TripRecordCommentNotFoundException;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
-import com.haejwo.tripcometrue.domain.member.exception.UserInvalidAccessException;
 import com.haejwo.tripcometrue.domain.member.exception.UserNotFoundException;
 import com.haejwo.tripcometrue.domain.member.repository.MemberRepository;
 import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
 import com.haejwo.tripcometrue.domain.review.placereview.exception.PlaceReviewNotFoundException;
 import com.haejwo.tripcometrue.domain.review.placereview.repository.PlaceReviewRepository;
-import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Objects;
 
 @Slf4j
 @Service
@@ -38,13 +31,13 @@ public class PlaceReviewCommentService {
     public void saveComment(
             PrincipalDetails principalDetails,
             Long placeReviewId,
-            PlaceReviewCommentRequestDto requestDto
+            com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto requestDto
     ) {
 
         Member loginMember = getMember(principalDetails);
         PlaceReview placeReview = getPlaceReviewById(placeReviewId);
 
-        PlaceReviewComment comment = PlaceReviewCommentRequestDto.toComment(loginMember, placeReview, requestDto);
+        PlaceReviewComment comment = com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto.toComment(loginMember, placeReview, requestDto);
         placeReviewCommentRepository.save(comment);
         placeReview.increaseCommentCount();
     }
@@ -59,25 +52,25 @@ public class PlaceReviewCommentService {
                 .orElseThrow(PlaceReviewNotFoundException::new);
     }
 
-//    public void saveReplyComment(
-//            PrincipalDetails principalDetails,
-//            Long tripRecordCommentId,
-//            TripRecordCommentRequestDto requestDto
-//    ) {
-//
-//        Member loginMember = getMember(principalDetails);
-//        TripRecordComment tripRecordComment = getTripRecordCommentById(tripRecordCommentId);
-//        TripRecord tripRecord = tripRecordComment.getTripRecord();
-//
-//        TripRecordComment comment = TripRecordCommentRequestDto.toReplyComment(loginMember, tripRecord, tripRecordComment, requestDto);
-//        tripRecordCommentRepository.save(comment);
-//        tripRecord.incrementCommentCount();
-//    }
-//
-//    private TripRecordComment getTripRecordCommentById(Long tripRecordCommentId) {
-//        return tripRecordCommentRepository.findById(tripRecordCommentId)
-//                .orElseThrow(TripRecordCommentNotFoundException::new);
-//    }
+    public void saveReplyComment(
+            PrincipalDetails principalDetails,
+            Long placeReviewCommentId,
+            PlaceReviewCommentRequestDto requestDto
+    ) {
+
+        Member loginMember = getMember(principalDetails);
+        PlaceReviewComment placeReviewComment = getPlaceReviewCommentById(placeReviewCommentId);
+        PlaceReview placeReview = placeReviewComment.getPlaceReview();
+
+        PlaceReviewComment comment = PlaceReviewCommentRequestDto.toReplyComment(loginMember, placeReview, placeReviewComment, requestDto);
+        placeReviewCommentRepository.save(comment);
+        placeReview.increaseCommentCount();
+    }
+
+    private PlaceReviewComment getPlaceReviewCommentById(Long tripRecordCommentId) {
+        return placeReviewCommentRepository.findById(tripRecordCommentId)
+                .orElseThrow(PlaceReviewCommentNotFoundException::new);
+    }
 //
 //    @Transactional(readOnly = true)
 //    public TripRecordCommentListResponseDto getCommentList(

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/controller/TripRecordCommentController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/controller/TripRecordCommentController.java
@@ -1,6 +1,6 @@
 package com.haejwo.tripcometrue.domain.comment.triprecord.controller;
 
-import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.CommentRequestDto;
+import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.TripRecordCommentRequestDto;
 import com.haejwo.tripcometrue.domain.comment.triprecord.dto.response.TripRecordCommentListResponseDto;
 import com.haejwo.tripcometrue.domain.comment.triprecord.service.TripRecordCommentService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
@@ -26,7 +26,7 @@ public class TripRecordCommentController {
     public ResponseEntity<ResponseDTO<Void>> registerComment(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long tripRecordId,
-            @RequestBody @Valid CommentRequestDto requestDto
+            @RequestBody @Valid TripRecordCommentRequestDto requestDto
     ) {
 
         commentService.saveComment(principalDetails, tripRecordId, requestDto);
@@ -37,7 +37,7 @@ public class TripRecordCommentController {
     public ResponseEntity<ResponseDTO<Void>> registerReplyComment(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long tripRecordCommentId,
-            @RequestBody @Valid CommentRequestDto requestDto
+            @RequestBody @Valid TripRecordCommentRequestDto requestDto
     ) {
 
         commentService.saveReplyComment(principalDetails, tripRecordCommentId, requestDto);

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/dto/request/TripRecordCommentRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/dto/request/TripRecordCommentRequestDto.java
@@ -6,7 +6,7 @@ import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 
-public record CommentRequestDto(
+public record TripRecordCommentRequestDto(
 
         @NotNull(message = "본문은 필수로 입력해야 합니다.")
         @Length(min = 1, max = 500, message = "작성 허용 범위는 최소 1자 또는 최대 500자 입니다.")
@@ -14,7 +14,7 @@ public record CommentRequestDto(
 
 ) {
 
-    public static TripRecordComment toComment(Member member, TripRecord tripRecord, CommentRequestDto requestDto) {
+    public static TripRecordComment toComment(Member member, TripRecord tripRecord, TripRecordCommentRequestDto requestDto) {
         return TripRecordComment.builder()
                 .member(member)
                 .tripRecord(tripRecord)
@@ -26,7 +26,7 @@ public record CommentRequestDto(
             Member member,
             TripRecord tripRecord,
             TripRecordComment tripRecordComment,
-            CommentRequestDto requestDto
+            TripRecordCommentRequestDto requestDto
     ) {
 
         return TripRecordComment.builder()

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/dto/response/TripRecordCommentResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/dto/response/TripRecordCommentResponseDto.java
@@ -15,6 +15,7 @@ public record TripRecordCommentResponseDto(
         Long memberId,
         String profileUrl,
         String nickname,
+        String content,
         boolean isWriter,
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
@@ -30,6 +31,7 @@ public record TripRecordCommentResponseDto(
                 tripRecordComment.getMember().getId(),
                 tripRecordComment.getMember().getProfileImage(),
                 tripRecordComment.getMember().getMemberBase().getNickname(),
+                tripRecordComment.getContent(),
                 isWriter(tripRecordComment, loginMember),
                 tripRecordComment.getCreatedAt(),
                 getReplyComments(tripRecordComment, loginMember) //자식 댓글 리스트에 담기

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/entity/TripRecordComment.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/entity/TripRecordComment.java
@@ -22,7 +22,7 @@ public class TripRecordComment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_id")
+    @Column(name = "trip_record_comment_id")
     private Long id;
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/service/TripRecordCommentService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/service/TripRecordCommentService.java
@@ -1,6 +1,6 @@
 package com.haejwo.tripcometrue.domain.comment.triprecord.service;
 
-import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.CommentRequestDto;
+import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.TripRecordCommentRequestDto;
 import com.haejwo.tripcometrue.domain.comment.triprecord.dto.response.TripRecordCommentListResponseDto;
 import com.haejwo.tripcometrue.domain.comment.triprecord.entity.TripRecordComment;
 import com.haejwo.tripcometrue.domain.comment.triprecord.exception.TripRecordCommentNotFoundException;
@@ -35,13 +35,13 @@ public class TripRecordCommentService {
     public void saveComment(
             PrincipalDetails principalDetails,
             Long tripRecordId,
-            CommentRequestDto requestDto
+            TripRecordCommentRequestDto requestDto
     ) {
 
         Member loginMember = getMember(principalDetails);
         TripRecord tripRecord = getTripRecordById(tripRecordId);
 
-        TripRecordComment comment = CommentRequestDto.toComment(loginMember, tripRecord, requestDto);
+        TripRecordComment comment = TripRecordCommentRequestDto.toComment(loginMember, tripRecord, requestDto);
         tripRecordCommentRepository.save(comment);
         tripRecord.incrementCommentCount();
     }
@@ -54,14 +54,14 @@ public class TripRecordCommentService {
     public void saveReplyComment(
             PrincipalDetails principalDetails,
             Long tripRecordCommentId,
-            CommentRequestDto requestDto
+            TripRecordCommentRequestDto requestDto
     ) {
 
         Member loginMember = getMember(principalDetails);
         TripRecordComment tripRecordComment = getTripRecordCommentById(tripRecordCommentId);
         TripRecord tripRecord = tripRecordComment.getTripRecord();
 
-        TripRecordComment comment = CommentRequestDto.toReplyComment(loginMember, tripRecord, tripRecordComment, requestDto);
+        TripRecordComment comment = TripRecordCommentRequestDto.toReplyComment(loginMember, tripRecord, tripRecordComment, requestDto);
         tripRecordCommentRepository.save(comment);
         tripRecord.incrementCommentCount();
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/controller/PlaceReviewController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/controller/PlaceReviewController.java
@@ -1,8 +1,5 @@
 package com.haejwo.tripcometrue.domain.review.placereview.controller;
 
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.MULTI_STATUS;
-
 import com.haejwo.tripcometrue.domain.review.placereview.dto.request.DeletePlaceReviewRequestDto;
 import com.haejwo.tripcometrue.domain.review.placereview.dto.request.PlaceReviewRequestDto;
 import com.haejwo.tripcometrue.domain.review.placereview.dto.response.PlaceReviewListResponseDto;

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/PlaceReviewListResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/PlaceReviewListResponseDto.java
@@ -1,6 +1,5 @@
 package com.haejwo.tripcometrue.domain.review.placereview.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
 import org.springframework.data.domain.Page;
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/PlaceReviewResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/dto/response/PlaceReviewResponseDto.java
@@ -1,9 +1,15 @@
 package com.haejwo.tripcometrue.domain.review.placereview.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.haejwo.tripcometrue.domain.comment.placereview.dto.response.PlaceReviewCommentResponseDto;
+import com.haejwo.tripcometrue.domain.comment.placereview.entity.PlaceReviewComment;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.review.placereview.entity.PlaceReview;
+import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
 
 public record PlaceReviewResponseDto(
 
@@ -19,21 +25,57 @@ public record PlaceReviewResponseDto(
         LocalDateTime createdAt,
 
         boolean amILike,
-        Integer commentCount
+        Integer commentCount,
+        List<PlaceReviewCommentResponseDto> comments
 
 ) {
-        public static PlaceReviewResponseDto fromEntity(PlaceReview placeReview, boolean amILike) {
-                return new PlaceReviewResponseDto(
-                        placeReview.getId(),
-                        placeReview.getMember().getId(),
-                        placeReview.getMember().getMemberBase().getNickname(),
-                        placeReview.getMember().getProfileImage(),
-                        placeReview.getImageUrl(),
-                        placeReview.getContent(),
-                        placeReview.getLikeCount(),
-                        placeReview.getCreatedAt(),
-                        amILike,
-                        placeReview.getCommentCount()
-                );
-        }
+
+    public static PlaceReviewResponseDto fromEntityWithComment(
+            PlaceReview placeReview,
+            boolean amILike,
+            Slice<PlaceReviewComment> placeReviewComments,
+            Member member
+    ) {
+
+        return new PlaceReviewResponseDto(
+                placeReview.getId(),
+                placeReview.getMember().getId(),
+                placeReview.getMember().getMemberBase().getNickname(),
+                placeReview.getMember().getProfileImage(),
+                placeReview.getImageUrl(),
+                placeReview.getContent(),
+                placeReview.getLikeCount(),
+                placeReview.getCreatedAt(),
+                amILike,
+                placeReview.getCommentCount(),
+                placeReviewComments.map(placeReviewComment -> {
+                            if (placeReviewComment.getParentComment() == null) {
+                                return PlaceReviewCommentResponseDto.fromEntity(placeReviewComment, member);
+                            }
+                            return null;
+                        })
+                        .filter(Objects::nonNull)
+                        .toList()
+        );
+    }
+
+    public static PlaceReviewResponseDto fromEntity(
+            PlaceReview placeReview,
+            boolean amILike
+    ) {
+
+        return new PlaceReviewResponseDto(
+                placeReview.getId(),
+                placeReview.getMember().getId(),
+                placeReview.getMember().getMemberBase().getNickname(),
+                placeReview.getMember().getProfileImage(),
+                placeReview.getImageUrl(),
+                placeReview.getContent(),
+                placeReview.getLikeCount(),
+                placeReview.getCreatedAt(),
+                amILike,
+                placeReview.getCommentCount(),
+                null
+        );
+    }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/entity/PlaceReview.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/entity/PlaceReview.java
@@ -87,8 +87,8 @@ public class PlaceReview extends BaseTimeEntity {
         commentCount += 1;
     }
 
-    public void decreaseCommentCount() {
-        commentCount -= 1;
+    public void decreaseCommentCount(int count) {
+        this.commentCount -= count;
     }
 
     @PrePersist

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/entity/PlaceReview.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/entity/PlaceReview.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static com.haejwo.tripcometrue.domain.review.global.PointType.ONLY_ONE_POINT;
 import static com.haejwo.tripcometrue.domain.review.global.PointType.TWO_POINTS;
+import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Getter
@@ -36,7 +37,7 @@ public class PlaceReview extends BaseTimeEntity {
     @JoinColumn(name = "place_id")
     private Place place;
 
-    @OneToMany(mappedBy = "placeReview")
+    @OneToMany(mappedBy = "placeReview", cascade = REMOVE, orphanRemoval = true)
     private List<PlaceReviewLikes> placeReviewLikeses = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/entity/PlaceReview.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/placereview/entity/PlaceReview.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static com.haejwo.tripcometrue.domain.review.global.PointType.ONLY_ONE_POINT;
 import static com.haejwo.tripcometrue.domain.review.global.PointType.TWO_POINTS;
-import static jakarta.persistence.CascadeType.*;
+import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.FetchType.LAZY;
 
 @Getter

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/entity/TripRecordReview.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/entity/TripRecordReview.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import static com.haejwo.tripcometrue.domain.review.global.PointType.ONLY_ONE_POINT;
 import static com.haejwo.tripcometrue.domain.review.global.PointType.TWO_POINTS;
-import static jakarta.persistence.CascadeType.*;
+import static jakarta.persistence.CascadeType.REMOVE;
 
 @Getter
 @Entity

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/entity/TripRecordReview.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/entity/TripRecordReview.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import static com.haejwo.tripcometrue.domain.review.global.PointType.ONLY_ONE_POINT;
 import static com.haejwo.tripcometrue.domain.review.global.PointType.TWO_POINTS;
+import static jakarta.persistence.CascadeType.*;
 
 @Getter
 @Entity
@@ -37,7 +38,7 @@ public class TripRecordReview extends BaseTimeEntity {
     @JoinColumn(name = "trip_record_id")
     private TripRecord tripRecord;
 
-    @OneToMany(mappedBy = "tripRecordReview")
+    @OneToMany(mappedBy = "tripRecordReview", cascade = REMOVE, orphanRemoval = true)
     private List<TripRecordReviewLikes> tripRecordReviewLikeses = new ArrayList<>();
 
     @NotNull

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/repository/TripRecordReviewRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/repository/TripRecordReviewRepository.java
@@ -15,16 +15,16 @@ import java.util.Optional;
 @Repository
 public interface TripRecordReviewRepository extends JpaRepository<TripRecordReview, Long>, TripRecordReviewRepositoryCustom {
 
-  @Query("select trr from TripRecordReview trr join fetch trr.member m where trr.member = :member and trr.content is not null order by trr.createdAt desc")
-  Page<TripRecordReview> findByMember(@Param("member") Member member, Pageable pageable);
+    @Query("select trr from TripRecordReview trr join fetch trr.member m where trr.member = :member and trr.content is not null order by trr.createdAt desc")
+    Page<TripRecordReview> findByMember(@Param("member") Member member, Pageable pageable);
 
-  @Query("select trr.ratingScore from TripRecordReview trr where trr.member = :member and trr.tripRecord.id = :tripRecordId")
-  Optional<Float> findMyScoreByMemberAndTripRecordId(@Param("member") Member member, @Param("tripRecordId") Long tripRecordId);
+    @Query("select trr.ratingScore from TripRecordReview trr where trr.member = :member and trr.tripRecord.id = :tripRecordId")
+    Optional<Float> findMyScoreByMemberAndTripRecordId(@Param("member") Member member, @Param("tripRecordId") Long tripRecordId);
 
-  @Query("select trr from TripRecordReview trr where trr.tripRecord.id = :tripRecordId and trr.content is not null order by trr.createdAt desc limit 1")
-  Optional<TripRecordReview> findTopByTripRecordIdOrderByCreatedAtDesc(@Param("tripRecordId") Long tripRecordId);
+    @Query("select trr from TripRecordReview trr where trr.tripRecord.id = :tripRecordId and trr.content is not null order by trr.createdAt desc limit 1")
+    Optional<TripRecordReview> findTopByTripRecordIdOrderByCreatedAtDesc(@Param("tripRecordId") Long tripRecordId);
 
-  boolean existsByMemberAndTripRecord(Member member, TripRecord tripRecord);
+    boolean existsByMemberAndTripRecord(Member member, TripRecord tripRecord);
 
-  Long countByTripRecordId(Long tripRecordId);
+    Long countByTripRecordId(Long tripRecordId);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
@@ -64,6 +64,9 @@ public class TripRecordReviewService {
     }
 
     private Member getMember(PrincipalDetails principalDetails) {
+        if (principalDetails == null) {
+            return null;
+        }
         return memberRepository.findById(principalDetails.getMember().getId())
                 .orElseThrow(UserNotFoundException::new);
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
@@ -215,9 +215,17 @@ public class TripRecordReviewService {
 
         return TripRecordReviewListResponseDto.fromResponseDtos(
                 reviews,
-                reviews.map(tripRecordReview -> TripRecordReviewResponseDto.fromEntity(
-                        tripRecordReview,
-                        hasLikedTripRecordReview(principalDetails, tripRecordReview))
+                reviews.map(tripRecordReview -> {
+                            boolean hasLiked = false;
+                            if (principalDetails != null) {
+                                hasLiked = hasLikedTripRecordReview(principalDetails, tripRecordReview);
+                            }
+                            return TripRecordReviewResponseDto.fromEntity(
+                                    tripRecordReview,
+                                    hasLiked
+
+                            );
+                        }
                 ).toList());
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/exception/ErrorCode.java
@@ -80,6 +80,7 @@ public enum ErrorCode {
 
     // COMMENT
     TRIP_RECORD_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행 후기 댓글입니다."),
+    PLACE_REVIEW_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 여행지 리뷰 댓글입니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)

- **간략한 설명**:
  : 여행지 리뷰 댓글, 대댓글에 대한 CURD 기능을 구현했습니다.

---

## 🛠 작성/변경 사항

### - 댓글 등록 기능 구현
  - 여행지 리뷰 id를 가지고 댓글을 등록합니다.
### - 대댓글 등록 기능 구현
  - 특정 댓글 id를 가지고 대댓글을 등록합니다.
### - 댓글, 대댓글 삭제 기능 구현
  - 정책상 부모 댓글을 삭제하면 자식 댓글(대댓글)도 전부 삭제됩니다.
### - 여행지 리뷰 조회/수정에서 댓글 조회 가능하도록 수정
  - 여행지 리뷰 댓글, 대댓글은 따로 조회가 불가능합니다.
  - 특정 `여행지 리뷰`(PlaceReview)를 조회하면 댓글도 함께 조회됩니다.
     ```json
        {
        "code": 200,
        "data": {
            "placeReviewId": 89,
            "memberId": 1,
            "nickname": "열받은너구리",
            "profileUrl": "https://tripcometrue-dev-s3-bucket.s3.ap-northeast-2.amazonaws.com/e3df3aed-95d1-4079-850e-3aac8d1dd4d5_Screen%20Shot%202023-12-22%20at%2011.52.41%20AM.png",
            "imageUrl": "https://tripcometrue-dev-s3-bucket.s3.ap-northeast-2.amazonaws.com/c75ca5b1-141d-4ca3-8e65-1253453dd30c.png",
            "content": "평야 양떼목장 양양 여자 섬 오렌지 흐림 산 오렌지",
            "likeCount": 0,
            "createdAt": "2024-01-15T00-01-57",
            "amILike": false
            "commentCount": 4,
            "comments": [
                {
                    "commentId": 31,
                    "memberId": 6,
                    "nickname": "심심한고슴도치",
                    "isWriter": true,
                    "content": "댓글 만세!!",
                    "createdAt": "2024-01-25T01-10-44",
                    "replyComments": [
                        {
                            "commentId": 35,
                            "memberId": 6,
                            "nickname": "심심한고슴도치",
                            "isWriter": true,
                            "content": "대댓글 입니다!!",
                            "createdAt": "2024-01-25T01-11-08"
                        }
                    ]
                },
                {
                    "commentId": 29,
                    "memberId": 6,
                    "nickname": "심심한고슴도치",
                    "isWriter": true,
                    "content": "댓글 만세!!",
                    "createdAt": "2024-01-25T01-10-42",
                    "replyComments": []
                }
            ]
        }
    }
    ```
  - 여행지 리뷰를 수정해도 동일하게 값이 반환됩니다.
### - 여행지 리뷰, 여행 후기 리뷰 모두 로그인하지 않은 유저도 조회 가능하도록 수정했습니다.
  - 로그인하지 않으면 `PrincipalDetails` 값이 null로 들어와 기존 코드에 예외가 발생했습니다.
  - 이를 방지하는 코드를 추가했습니다.
  - 
    ```java
    // principalDetails가 null인 경우를 고려해 if문으로 분기점 생성
    return PlaceReviewListResponseDto.fromResponseDtos(
                reviews,
                reviews.map(placeReview -> {
                            boolean hasLiked = false;
                            if (principalDetails != null) {
                                hasLiked = hasLikedPlaceReview(principalDetails, placeReview);
                            }
                            return PlaceReviewResponseDto.fromEntity(
                                    placeReview,
                                    hasLiked
                            );
                        }
                ).toList());
    ```
---

## 🔗 관련 이슈

- **이슈 링크1** : #12 

---

## 💡 특이 사항

### - 로그인하지 않은 사용자를 고려해 코드를 짤 필요가 있습니다.
  - 처음 설계때부터 로그인 유저만을 상정했기 때문에 추후 로그인하지 않은 상황을 생각하니 코드가 지져분해진 느낌을 받습니다.
  - 다음부터는 로그인이 되지 않아 `principalDetails`가 `null` 인 경우부터 고려해서 설계할 필요성을 느꼈습니다.

### - 객체지향적으로 짜지 못한 것 같습니다.
  - 기존의 여행지 리뷰(PlaceReview) 1건 조회하는 코드에, 댓글 조회 코드를 합치는 과정에서 매개변수들이 추가되었습니다. 맞지 않는 옷을 억지로 껴 입는 느낌을 받았습니다.
  - 어떻게 하면 객체지향적으로 코드를 작성할 수 있을지 고민이 많이 되는 부분이었습니다.
 
---
