### PR TITLE
[feat] 여행후기, 여행지 상세페이지 응답 사용자 보관유무 추가

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/controller/PlaceController.java
@@ -6,6 +6,7 @@ import com.haejwo.tripcometrue.domain.place.dto.response.PlaceMapInfoResponseDto
 import com.haejwo.tripcometrue.domain.place.dto.response.PlaceNearbyResponseDto;
 import com.haejwo.tripcometrue.domain.place.dto.response.PlaceResponseDto;
 import com.haejwo.tripcometrue.domain.place.service.PlaceService;
+import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.ResponseDTO;
 import java.util.List;
 
@@ -17,6 +18,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,10 +51,11 @@ public class PlaceController {
 
     @GetMapping("/{placeId}")
     public ResponseEntity<ResponseDTO<PlaceResponseDto>> placeDetails(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
         @PathVariable Long placeId
     ) {
 
-        PlaceResponseDto responseDto = placeService.findPlace(placeId);
+        PlaceResponseDto responseDto = placeService.findPlace(principalDetails, placeId);
         ResponseDTO<PlaceResponseDto> responseBody = ResponseDTO.okWithData(responseDto);
 
         return ResponseEntity

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/dto/response/PlaceResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/dto/response/PlaceResponseDto.java
@@ -18,6 +18,7 @@ public record PlaceResponseDto(
     Double latitude,
     Double longitude,
     Integer storedCount,
+    Boolean isStored,
     Long cityId
 ) {
 
@@ -28,7 +29,7 @@ public record PlaceResponseDto(
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm") LocalTime weekdayCloseTime,
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm") LocalTime weekendOpenTime,
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm") LocalTime weekendCloseTime,
-        Double latitude, Double longitude, Integer storedCount, Long cityId) {
+        Double latitude, Double longitude, Integer storedCount, Boolean isStored, Long cityId) {
         this.id = id;
         this.name = name;
         this.address = address;
@@ -41,6 +42,7 @@ public record PlaceResponseDto(
         this.latitude = latitude;
         this.longitude = longitude;
         this.storedCount = storedCount;
+        this.isStored = isStored;
         this.cityId = cityId;
     }
 
@@ -58,6 +60,25 @@ public record PlaceResponseDto(
             .latitude(entity.getLatitude())
             .longitude(entity.getLongitude())
             .storedCount(entity.getStoredCount())
+            .cityId(entity.getCity().getId())
+            .build();
+    }
+
+    public static PlaceResponseDto fromEntity(Place entity, Boolean isStored) {
+        return PlaceResponseDto.builder()
+            .id(entity.getId())
+            .name(entity.getName())
+            .address(entity.getAddress())
+            .description(entity.getDescription())
+            .phoneNumber(entity.getPhoneNumber())
+            .weekdayOpenTime(entity.getWeekdayOpenTime())
+            .weekdayCloseTime(entity.getWeekdayCloseTime())
+            .weekendOpenTime(entity.getWeekendOpenTime())
+            .weekendCloseTime(entity.getWeekendCloseTime())
+            .latitude(entity.getLatitude())
+            .longitude(entity.getLongitude())
+            .storedCount(entity.getStoredCount())
+            .isStored(isStored)
             .cityId(entity.getCity().getId())
             .build();
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/service/PlaceService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/service/PlaceService.java
@@ -11,6 +11,8 @@ import com.haejwo.tripcometrue.domain.place.dto.response.PlaceResponseDto;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.domain.place.exception.PlaceNotFoundException;
 import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
+import com.haejwo.tripcometrue.domain.store.repository.PlaceStoreRepository;
+import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import java.util.List;
 import java.util.Objects;
 
@@ -33,6 +35,7 @@ public class PlaceService {
     private final PlaceRepository placeRepository;
     private final CityRepository cityRepository;
     private final TripRecordScheduleImageRepository tripRecordScheduleImageRepository;
+    private final PlaceStoreRepository placeStoreRepository;
 
     @Transactional
     public PlaceResponseDto addPlace(PlaceRequestDto requestDto) {
@@ -47,11 +50,16 @@ public class PlaceService {
     }
 
     @Transactional(readOnly = true)
-    public PlaceResponseDto findPlace(Long placeId) {
+    public PlaceResponseDto findPlace(PrincipalDetails principalDetails, Long placeId) {
 
         Place findPlace = findPlaceById(placeId);
+        
+        Boolean isStored = false;
+        if(principalDetails != null) {
+            isStored = placeStoreRepository.existsByMemberAndPlace(principalDetails.getMember(), findPlace);
+        }
 
-        PlaceResponseDto responseDto = PlaceResponseDto.fromEntity(findPlace);
+        PlaceResponseDto responseDto = PlaceResponseDto.fromEntity(findPlace, isStored);
 
         return responseDto;
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/repository/PlaceStoreRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/repository/PlaceStoreRepository.java
@@ -19,4 +19,6 @@ public interface PlaceStoreRepository extends JpaRepository<PlaceStore, Long> {
 
   Long countByPlace(Place place);
 
+  Boolean existsByMemberAndPlace(Member member, Place place);
+
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/repository/TripRecordStoreRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/repository/TripRecordStoreRepository.java
@@ -18,4 +18,6 @@ public interface TripRecordStoreRepository extends JpaRepository <TripRecordStor
 
   Long countByTripRecord(TripRecord tripRecord);
 
+  Boolean existsByMemberAndTripRecord(Member member, TripRecord tripRecord);
+
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordDetailResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord/TripRecordDetailResponseDto.java
@@ -30,6 +30,7 @@ public record TripRecordDetailResponseDto(
     Integer totalDays,
     Double averageRating,
     Integer storeCount,
+    Boolean isStored,
     TripRecordMemberResponseDto member,
     List<TripRecordImageResponseDto> images,
     List<TripRecordTagResponseDto> tags,
@@ -42,7 +43,7 @@ public record TripRecordDetailResponseDto(
         ExpenseRangeType expenseRangeType, String countries,
         @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd") LocalDate tripStartDay,
         @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd") LocalDate tripEndDay,
-        Integer totalDays, Double averageRating, Integer storeCount,
+        Integer totalDays, Double averageRating, Integer storeCount, Boolean isStored,
         TripRecordMemberResponseDto member, List<TripRecordImageResponseDto> images,
         List<TripRecordTagResponseDto> tags,
         Map<LocalDate, List<TripRecordScheduleDetailResponseDto>> schedules) {
@@ -56,15 +57,14 @@ public record TripRecordDetailResponseDto(
         this.totalDays = totalDays;
         this.averageRating = averageRating;
         this.storeCount = storeCount;
+        this.isStored = isStored;
         this.member = member;
         this.images = images;
         this.tags = tags;
         this.schedules = schedules;
     }
 
-
-
-    public static TripRecordDetailResponseDto fromEntity(TripRecord entity) {
+    public static TripRecordDetailResponseDto fromEntity(TripRecord entity, Boolean isStored) {
 
         TripRecordMemberResponseDto member = TripRecordMemberResponseDto.fromEntity(entity.getMember());
 
@@ -111,6 +111,7 @@ public record TripRecordDetailResponseDto(
             .tripEndDay(entity.getTripEndDay())
             .totalDays(entity.getTotalDays())
             .storeCount(entity.getStoreCount())
+            .isStored(isStored)
             .averageRating(entity.getAverageRating())
             .member(member)
             .images(imageDtos)

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule_media/TripRecordScheduleImageListResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/dto/response/triprecord_schedule_media/TripRecordScheduleImageListResponseDto.java
@@ -5,14 +5,14 @@ import lombok.Builder;
 public record TripRecordScheduleImageListResponseDto(
     Long tripRecordId,
     String imageUrl,
-    Integer TripRecordStoreNum
+    Integer tripRecordStoreCount
 ) {
 
     @Builder
     public TripRecordScheduleImageListResponseDto(Long tripRecordId, String imageUrl,
-        Integer TripRecordStoreNum) {
+        Integer tripRecordStoreCount) {
         this.tripRecordId = tripRecordId;
         this.imageUrl = imageUrl;
-        this.TripRecordStoreNum = TripRecordStoreNum;
+        this.tripRecordStoreCount = tripRecordStoreCount;
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -1,8 +1,12 @@
 package com.haejwo.tripcometrue.domain.triprecord.service;
 
+import com.haejwo.tripcometrue.domain.store.repository.TripRecordStoreRepository;
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.ModelAttribute.TripRecordListRequestAttribute;
 import com.haejwo.tripcometrue.domain.triprecord.dto.request.ModelAttribute.TripRecordSearchParamAttribute;
-import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.*;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.MyTripRecordListResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordDetailResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListItemResponseDto;
+import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord.TripRecordListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media.TripRecordHotShortsListResponseDto;
 import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedule_media.TripRecordScheduleVideoDetailDto;
 import com.haejwo.tripcometrue.domain.triprecord.entity.TripRecord;
@@ -17,16 +21,15 @@ import com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_viewcount
 import com.haejwo.tripcometrue.domain.triprecordViewHistory.service.TripRecordViewHistoryService;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import com.haejwo.tripcometrue.global.util.SliceResponseDto;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +40,7 @@ public class TripRecordService {
     private final TripRecordViewCountRepository tripRecordViewCountRepository;
     private final TripRecordViewHistoryService tripRecordViewHistoryService;
     private final TripRecordScheduleVideoRepository tripRecordScheduleVideoRepository;
+    private final TripRecordStoreRepository tripRecordStoreRepository;
 
     private static final int HOME_CONTENT_SIZE = 5;
 
@@ -46,6 +50,7 @@ public class TripRecordService {
         TripRecord findTripRecord = findTripRecordById(tripRecordId);
 
         Long memberId = null;
+        Boolean isStored = false;
 
         if(principalDetails != null){
             memberId = principalDetails.getMember().getId();
@@ -56,9 +61,10 @@ public class TripRecordService {
 
         if(principalDetails != null) {
             tripRecordViewHistoryService.addViewHistory(principalDetails, tripRecordId);
+            isStored = tripRecordStoreRepository.existsByMemberAndTripRecord(principalDetails.getMember(), findTripRecord);
         }
 
-        TripRecordDetailResponseDto responseDto = TripRecordDetailResponseDto.fromEntity(findTripRecord);
+        TripRecordDetailResponseDto responseDto = TripRecordDetailResponseDto.fromEntity(findTripRecord, isStored);
 
         return responseDto;
     }


### PR DESCRIPTION
## 🎯 목적

- [X] 새 기능 (New Feature)
- [X] 리팩토링 (Refactoring)
- [ ] 버그 수정 (Bug Fix)
- [ ] 테스트 (Test)
- [ ] CI/CD
- [ ] 설정 (Setup)

- **간략한 설명**:
  : 여행후기, 여행지 상세페이지 응답 사용자 보관유무 추가

---

## 🛠 작성/변경 사항

- **(주요작성/변경사항)**
- 여행후기 상세페이지 응답 사용자 보관유무 추가
- 여행지 상세페이지 응답 사용자 보관유무 추가
- 여행지 상세 페이지의 여행갤러리 응답데이터 수정 

---

## 🔗 관련 이슈

- **이슈 링크1** : #112 

---

## 💡 특이 사항

- **주목할 사항** 
  - (특이사항1)
  - 

---

## 📖 문서화

- **관련 문서 링크** 
  - (링크1)
  - 
---

## 🧪 테스트

- **테스트 계획 및 결과** 
  - (테스트계획)
  - (테스트결과)

---

## 📚 참조

- **참조 링크**
  - (링크1)
 
- **참고 자료**
  - (자료1)
