### PR TITLE
[refactor] 도시 상세 환율 정보 조회 API 변경 및 로직 리팩토링 수정

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityInfoReadController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityInfoReadController.java
@@ -31,15 +31,15 @@ public class CityInfoReadController {
             );
     }
 
-    @GetMapping("/exchange-rates")
+    @GetMapping("/{cityId}/exchange-rates")
     public ResponseEntity<ResponseDTO<ExchangeRateResponseDto>> getExchangeRate(
-        @RequestParam(name = "curUnit") String curUnit
+        @PathVariable("cityId") Long cityId
     ) {
 
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(
-                ResponseDTO.okWithData(cityInfoReadService.getExchangeRate(curUnit))
+                ResponseDTO.okWithData(cityInfoReadService.getExchangeRateByCityId(cityId))
             );
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityInfoReadService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityInfoReadService.java
@@ -18,7 +18,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -39,9 +38,12 @@ public class CityInfoReadService {
     }
 
     @Transactional(readOnly = true)
-    public ExchangeRateResponseDto getExchangeRate(String curUnit) {
-        CurrencyUnit currencyUnit = validateAndConvertToCurrencyUnit(curUnit);
+    public ExchangeRateResponseDto getExchangeRateByCityId(Long cityId) {
 
+        City city = cityRepository.findById(cityId)
+            .orElseThrow(CityNotFoundException::new);
+
+        CurrencyUnit currencyUnit = city.getCurrency();
         String exchangeRate = (String) redisTemplate.opsForValue()
             .get("exchange-rate:" + currencyUnit);
 
@@ -104,12 +106,5 @@ public class CityInfoReadService {
             .add(new BigDecimal("32"))
             .setScale(2, RoundingMode.HALF_UP)
             .toString();
-    }
-
-    private CurrencyUnit validateAndConvertToCurrencyUnit(String curUnit) {
-        return Arrays.stream(CurrencyUnit.values())
-            .filter(currencyUnit -> currencyUnit.name().equals(curUnit.toUpperCase()))
-            .findFirst()
-            .orElseThrow();
     }
 }


### PR DESCRIPTION
## 🎯 목적

- [x] 리팩토링 (Refactoring)

- **간략한 설명**:
  : 프론트 요청에 따른 도시 상세 환율 정보 조회 API 변경 및 로직 수정
 
---

## 🛠 작성/변경 사항

- ### **변경사항**
    - 기존 : '/v1/cities/exchange-rates?curUnit={curUnit}'
      - 도시의 환율 단위를 RequestParam으로 요청값으로 받아 환율 정보 조회
   - 변경 후 : '/v1/cities/{cityId}/exchange-rates'
     - 도시 식별자를 요청값으로 받아 도시 엔티티로부터 환율 단위를 추출해 환율 정보 조회
---

## 🔗 관련 이슈

- **이슈 링크** : #119 

---

This close #119 
