### PR TITLE
[feat] 여행 후기 리뷰(TripRecordReview)의 본문(content) 작성 가능 여부 검증 로직 구현

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/dto/response/latest/EmptyTripRecordReviewResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/dto/response/latest/EmptyTripRecordReviewResponseDto.java
@@ -4,10 +4,11 @@ public record EmptyTripRecordReviewResponseDto(
 
         Long totalCount,
         Long myTripRecordReviewId,
-        Float myRatingScore
+        Float myRatingScore,
+        boolean canRegisterContent
 
 ) implements LatestReviewResponseDto {
-    public static EmptyTripRecordReviewResponseDto fromData(Long totalCount, Long myTripRecordReviewId, Float myRatingScore) {
-        return new EmptyTripRecordReviewResponseDto(totalCount, myTripRecordReviewId, myRatingScore);
+    public static EmptyTripRecordReviewResponseDto fromData(Long totalCount, Long myTripRecordReviewId, Float myRatingScore, boolean canRegisterContent) {
+        return new EmptyTripRecordReviewResponseDto(totalCount, myTripRecordReviewId, myRatingScore, canRegisterContent);
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/dto/response/latest/EmptyTripRecordReviewResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/dto/response/latest/EmptyTripRecordReviewResponseDto.java
@@ -3,10 +3,11 @@ package com.haejwo.tripcometrue.domain.review.triprecordreview.dto.response.late
 public record EmptyTripRecordReviewResponseDto(
 
         Long totalCount,
+        Long myTripRecordReviewId,
         Float myRatingScore
 
 ) implements LatestReviewResponseDto {
-    public static EmptyTripRecordReviewResponseDto fromData(Long totalCount, Float myRatingScore) {
-        return new EmptyTripRecordReviewResponseDto(totalCount, myRatingScore);
+    public static EmptyTripRecordReviewResponseDto fromData(Long totalCount, Long myTripRecordReviewId, Float myRatingScore) {
+        return new EmptyTripRecordReviewResponseDto(totalCount, myTripRecordReviewId, myRatingScore);
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/dto/response/latest/LatestTripRecordReviewResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/dto/response/latest/LatestTripRecordReviewResponseDto.java
@@ -8,18 +8,21 @@ public record LatestTripRecordReviewResponseDto(
         Long totalCount,
         TripRecordReviewResponseDto latestTripRecordReview,
         Long myTripRecordReviewId,
-        Float myRatingScore
+        Float myRatingScore,
+        boolean canRegisterContent
 
 ) implements LatestReviewResponseDto {
     public static LatestTripRecordReviewResponseDto fromEntity(
             Long totalCount,
             TripRecordReview tripRecordReview,
             Long myTripRecordReviewId,
-            Float myRatingScore) {
+            Float myRatingScore,
+            boolean canRegisterContent) {
         return new LatestTripRecordReviewResponseDto(
                 totalCount,
                 TripRecordReviewResponseDto.fromEntity(tripRecordReview, false),
                 myTripRecordReviewId,
-                myRatingScore);
+                myRatingScore,
+                canRegisterContent);
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/dto/response/latest/LatestTripRecordReviewResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/dto/response/latest/LatestTripRecordReviewResponseDto.java
@@ -7,13 +7,19 @@ public record LatestTripRecordReviewResponseDto(
 
         Long totalCount,
         TripRecordReviewResponseDto latestTripRecordReview,
+        Long myTripRecordReviewId,
         Float myRatingScore
 
 ) implements LatestReviewResponseDto {
-    public static LatestTripRecordReviewResponseDto fromEntity(Long totalCount, TripRecordReview tripRecordReview, Float myRatingScore) {
+    public static LatestTripRecordReviewResponseDto fromEntity(
+            Long totalCount,
+            TripRecordReview tripRecordReview,
+            Long myTripRecordReviewId,
+            Float myRatingScore) {
         return new LatestTripRecordReviewResponseDto(
                 totalCount,
                 TripRecordReviewResponseDto.fromEntity(tripRecordReview, false),
+                myTripRecordReviewId,
                 myRatingScore);
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/repository/TripRecordReviewRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/repository/TripRecordReviewRepository.java
@@ -18,13 +18,14 @@ public interface TripRecordReviewRepository extends JpaRepository<TripRecordRevi
     @Query("select trr from TripRecordReview trr join fetch trr.member m where trr.member = :member and trr.content is not null order by trr.createdAt desc")
     Page<TripRecordReview> findByMember(@Param("member") Member member, Pageable pageable);
 
-    @Query("select trr.ratingScore from TripRecordReview trr where trr.member = :member and trr.tripRecord.id = :tripRecordId")
-    Optional<Float> findMyScoreByMemberAndTripRecordId(@Param("member") Member member, @Param("tripRecordId") Long tripRecordId);
+    @Query("select trr from TripRecordReview trr where trr.member = :member and trr.tripRecord.id = :tripRecordId")
+    Optional<TripRecordReview> findByMemberAndTripRecordId(@Param("member") Member member, @Param("tripRecordId") Long tripRecordId);
 
     @Query("select trr from TripRecordReview trr where trr.tripRecord.id = :tripRecordId and trr.content is not null order by trr.createdAt desc limit 1")
     Optional<TripRecordReview> findTopByTripRecordIdOrderByCreatedAtDesc(@Param("tripRecordId") Long tripRecordId);
 
     boolean existsByMemberAndTripRecord(Member member, TripRecord tripRecord);
 
+    @Query("select count(trr) from TripRecordReview trr where trr.content is not null")
     Long countByTripRecordId(Long tripRecordId);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
@@ -182,16 +182,19 @@ public class TripRecordReviewService {
         Member loginMember = getMember(principalDetails);
 
         Long totalCount = tripRecordReviewRepository.countByTripRecordId(tripRecordId);
-        Float myScore = tripRecordReviewRepository
-                .findMyScoreByMemberAndTripRecordId(loginMember, tripRecordId).orElse(0f);
+        Optional<TripRecordReview> myReview = tripRecordReviewRepository
+                .findByMemberAndTripRecordId(loginMember, tripRecordId);
+
+        Long myReviewId = myReview.map(TripRecordReview::getId).orElse(null);
+        Float myRatingScore = myReview.map(TripRecordReview::getRatingScore).orElse(0f);
 
         Optional<TripRecordReview> latestReview = tripRecordReviewRepository
                 .findTopByTripRecordIdOrderByCreatedAtDesc(tripRecordId);
 
         if (latestReview.isEmpty()) {
-            return EmptyTripRecordReviewResponseDto.fromData(totalCount, myScore);
+            return EmptyTripRecordReviewResponseDto.fromData(totalCount, myReviewId, myRatingScore);
         }
-        return LatestTripRecordReviewResponseDto.fromEntity(totalCount, latestReview.get(), myScore);
+        return LatestTripRecordReviewResponseDto.fromEntity(totalCount, latestReview.get(), myReviewId, myRatingScore);
     }
 
     public SimpleTripRecordResponseDto getTripRecordReview(PrincipalDetails principalDetails, Long tripRecordReviewId) {

--- a/src/main/java/com/haejwo/tripcometrue/domain/tripplan/repository/TripPlanRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/tripplan/repository/TripPlanRepository.java
@@ -1,12 +1,19 @@
 package com.haejwo.tripcometrue.domain.tripplan.repository;
 
+import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.tripplan.entity.TripPlan;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface TripPlanRepository extends JpaRepository<TripPlan, Long> {
 
   Page<TripPlan> findByMemberId(Long memberId, Pageable pageable);
+
+  @Query("select tp from TripPlan tp where tp.member = :member and tp.referencedBy = :tripRecordId order by tp.tripEndDay asc limit 1")
+  Optional<TripPlan> findByMemberIdAndTripRecordId(@Param("member") Member loginMember, @Param("tripRecordId") Long tripRecordId);
 }


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)

- **간략한 설명**:
  - 여행 후기 리뷰에서 본문을 작성할 수 있는지 여부를 검증하고 반환하는 기능을 구현했습니다.
 
      <img src="https://github.com/TripComeTrue/TripComeTrue_BE/assets/85631282/9f47df6b-f0ad-4a45-8fd4-3016cc6889e5)" width="40%" height="40%"/>
  - `canRegisterContent` 값으로 작성 가능 여부를 반환합니다.
  
      <img src="https://github.com/TripComeTrue/TripComeTrue_BE/assets/85631282/ab59b669-9677-4162-9711-1c5363194b69)" width="60%" height="60%"/>

  - 로그인한 사용자가 등록한 `여행 후기 별점 id`를 반환합니다.

---

## 🛠 작성/변경 사항

### - 여행 후기 리뷰 본문을 작성할 수 있는지 확인합니다.
  - 작성 여부는 몇 가지 기준으로 판단합니다.
      #### 1. 여행 후기 리뷰를 복사해서 계획 등록까지 완료해야 합니다. 단순히 여행 계획을 작성한 사례라면 유효하지 않습니다.
      #### 2. 등록한 여행 계획의 여행 종료 시점(tripEndDay)이 오늘 날짜보다 최소 하루 과거여야 합니다.
      #### 3. 유저가 여행 후기 리뷰에 별점(ratingScore)를 먼저 등록해야 합니다.
      #### 4. 유저가 이미 여행 후기 리뷰의 `content`를 작성하지 않았어야 합니다.
---

## 🔗 관련 이슈

- **이슈 링크1** : #8 
