### PR TITLE
도시 상세 피드 여행지 검색 조회 API 구현

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityContentReadController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/controller/CityContentReadController.java
@@ -107,16 +107,17 @@ public class CityContentReadController {
             );
     }
 
-    // 도시 여행지 더보기 조회
+    // 도시 여행지 더보기 조회 및 도시 여행지 검색 조회 (페이징)
     @GetMapping("/{cityId}/places")
     public ResponseEntity<ResponseDTO<SliceResponseDto<CityPlaceResponseDto>>> getPlacesByCityIdPagination(
         @PathVariable("cityId") Long cityId,
+        @RequestParam(required = false, name = "placeName") String placeName,
         @PageableDefault(sort = "storedCount", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(
-                ResponseDTO.okWithData(cityContentReadService.getPlaces(cityId, pageable))
+                ResponseDTO.okWithData(cityContentReadService.getPlaces(cityId, placeName, pageable))
             );
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepository.java
@@ -17,7 +17,7 @@ public interface PlaceCustomRepository {
 
     Slice<Place> findPlacesByCityIdAndPlaceName(Long cityId, String placeName, Pageable pageable);
 
-    Slice<Place> findPlacesWithCityByName(String placeName, Pageable pageable);
+    Slice<Place> findPlacesWithCityByPlaceName(String placeName, Pageable pageable);
 
     List<Place> findPlacesByCityAndOrderByStoredCountLimitSize(City city, int size);
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepository.java
@@ -15,7 +15,7 @@ public interface PlaceCustomRepository {
     Page<Place> findPlaceWithFilter(Pageable pageable,
                                     Integer storedCount);
 
-    Slice<Place> findPlacesByCityId(Long cityId, Pageable pageable);
+    Slice<Place> findPlacesByCityIdAndPlaceName(Long cityId, String placeName, Pageable pageable);
 
     Slice<Place> findPlacesWithCityByName(String placeName, Pageable pageable);
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepositoryImpl.java
@@ -10,8 +10,10 @@ import com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordSchedule;
 import com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordScheduleImage;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.NullExpression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.OrderSpecifier.NullHandling;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -268,6 +270,10 @@ public class PlaceCustomRepositoryImpl extends QuerydslRepositorySupport impleme
             }
         }
 
-        return orderSpecifiers.isEmpty() ? null : orderSpecifiers.toArray(OrderSpecifier[]::new);
+        if(orderSpecifiers.isEmpty()) {
+            orderSpecifiers.add(new OrderSpecifier(Order.ASC, NullExpression.DEFAULT, NullHandling.Default));
+        }
+
+        return orderSpecifiers.toArray(OrderSpecifier[]::new);
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceCustomRepositoryImpl.java
@@ -92,7 +92,7 @@ public class PlaceCustomRepositoryImpl extends QuerydslRepositorySupport impleme
     }
 
     @Override
-    public Slice<Place> findPlacesWithCityByName(String placeName, Pageable pageable) {
+    public Slice<Place> findPlacesWithCityByPlaceName(String placeName, Pageable pageable) {
 
         int pageSize = pageable.getPageSize();
         List<Place> content = queryFactory

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/service/PlaceService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/service/PlaceService.java
@@ -79,7 +79,7 @@ public class PlaceService {
     public SliceResponseDto<PlaceListItemResponseDto> listPlacesByName(
         String placeName, Pageable pageable
     ) {
-        Slice<Place> places = placeRepository.findPlacesWithCityByName(placeName, pageable);
+        Slice<Place> places = placeRepository.findPlacesWithCityByPlaceName(placeName, pageable);
 
         return SliceResponseDto.of(
             places.map(

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordCustomRepositoryImpl.java
@@ -10,8 +10,10 @@ import com.haejwo.tripcometrue.domain.triprecord.entity.*;
 import com.haejwo.tripcometrue.domain.triprecord.entity.type.ExpenseRangeType;
 import com.haejwo.tripcometrue.global.enums.Country;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.NullExpression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.OrderSpecifier.NullHandling;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -387,6 +389,10 @@ public class TripRecordCustomRepositoryImpl extends QuerydslRepositorySupport im
             }
         }
 
-        return orderSpecifiers.isEmpty() ? null : orderSpecifiers.toArray(OrderSpecifier[]::new); // 최신순
+        if(orderSpecifiers.isEmpty()) {
+            orderSpecifiers.add(new OrderSpecifier(Order.ASC, NullExpression.DEFAULT, NullHandling.Default));
+        }
+
+        return orderSpecifiers.toArray(OrderSpecifier[]::new);
     }
 }

--- a/src/test/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.haejwo.tripcometrue.domain.place.repositroy;
+
+import com.haejwo.tripcometrue.config.TestQuerydslConfig;
+import com.haejwo.tripcometrue.domain.place.entity.Place;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Slf4j
+@Sql(scripts = "classpath:sql/test-data-insert.sql")
+@ActiveProfiles("test")
+@Import(TestQuerydslConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class PlaceRepositoryTest {
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Test
+    void findPlacesByCityIdAndPlaceName() {
+        // given
+        Long cityId = 1L;
+        String placeName = "여 행";
+        int pageSize = 2;
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+
+        // when
+        Slice<Place> result = placeRepository.findPlacesByCityIdAndPlaceName(cityId, placeName, pageRequest);
+
+        // then
+        assertThat(result.getNumberOfElements()).isEqualTo(pageSize);
+        assertThat(result.isFirst()).isTrue();
+        assertThat(result.isLast()).isTrue();
+    }
+
+    @Test
+    void findPlacesByCityIdAndPlaceName_nullPlaceName() {
+        // given
+        Long cityId = 1L;
+        String placeName = null;
+        int pageSize = 2;
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+
+        // when
+        Slice<Place> result = placeRepository.findPlacesByCityIdAndPlaceName(cityId, placeName, pageRequest);
+
+        // then
+        assertThat(result.getNumberOfElements()).isEqualTo(pageSize);
+        assertThat(result.isFirst()).isTrue();
+        assertThat(result.isLast()).isTrue();
+    }
+
+    @Test
+    void findPlacesByCityIdAndPlaceName_blankPlaceName() {
+        // given
+        Long cityId = 1L;
+        String placeName = "  ";
+        int pageSize = 2;
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+
+        // when
+        Slice<Place> result = placeRepository.findPlacesByCityIdAndPlaceName(cityId, placeName, pageRequest);
+
+        // then
+        assertThat(result.getNumberOfElements()).isEqualTo(pageSize);
+        assertThat(result.isFirst()).isTrue();
+        assertThat(result.isLast()).isTrue();
+    }
+
+}


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)
- [x] 리팩토링 (Refactoring)

- **간략한 설명**:
  : 도시 상세 피드 여행지 검색 조회 API 구현

---

## 🛠 작성/변경 사항

- ### **(주요작성/변경사항)**
   - 기존 도시 여행 전체 페이징 조회 API에 여행지명 검색 기능 추가 
      -  '/v1/cities/{cityId}/places/list?placeName={placeName}'
   - Querydsl OrderSpecifier 'order by null' 정렬 기준 추가
  
---

## 🔗 관련 이슈

- **이슈 링크** : #122 

---

This close #122 
