### PR TITLE
[feat] 마이페이지 알림 보관 리스트 기능 구현

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/alarm/controller/AlarmController.java
@@ -1,0 +1,30 @@
+package com.haejwo.tripcometrue.domain.alarm.controller;
+
+import com.haejwo.tripcometrue.domain.alarm.dto.response.AlarmResponseDto;
+import com.haejwo.tripcometrue.domain.alarm.service.AlarmService;
+import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
+import com.haejwo.tripcometrue.global.util.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AlarmController {
+
+  private final AlarmService alarmService;
+
+
+  @GetMapping("/v1/member/alarms")
+  public ResponseEntity<ResponseDTO<Page<AlarmResponseDto>>> getAlarms(
+      @AuthenticationPrincipal PrincipalDetails principalDetails,
+      Pageable pageable
+  ) {
+    Page<AlarmResponseDto> alarmsResponse = alarmService.getAlarms(principalDetails, pageable);
+    return ResponseEntity.ok(ResponseDTO.okWithData(alarmsResponse));
+  }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/alarm/dto/response/AlarmResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/alarm/dto/response/AlarmResponseDto.java
@@ -1,0 +1,30 @@
+package com.haejwo.tripcometrue.domain.alarm.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.haejwo.tripcometrue.domain.alarm.entity.Alarm;
+import com.haejwo.tripcometrue.domain.alarm.entity.AlarmType;
+import java.time.LocalDateTime;
+
+public record AlarmResponseDto(
+    Long alarmId,
+    String alarmArgs,
+    String fromMemberNickname,
+    Long windowId,
+    Long objectId,
+    AlarmType alarmType,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH-mm-ss")
+    LocalDateTime createdAt
+) {
+
+  public static AlarmResponseDto fromEntity(Alarm alarm) {
+    return new AlarmResponseDto(
+        alarm.getId(),
+        alarm.getAlarmArgs(),
+        alarm.getFromMember().getMemberBase().getNickname(),
+        alarm.getWindowId(),
+        alarm.getObjectId(),
+        alarm.getAlarmType(),
+        alarm.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/alarm/entity/Alarm.java
@@ -1,0 +1,62 @@
+package com.haejwo.tripcometrue.domain.alarm.entity;
+
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Alarm extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "alarm_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "from_member_id")
+  private Member fromMember;
+
+  private Long windowId;
+  private Long objectId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "to_member_id")
+  private Member toMember;
+
+  @Enumerated(EnumType.STRING)
+  private AlarmType alarmType;
+
+  private String alarmArgs;
+
+
+  @Builder
+  public Alarm(
+      Member fromMember,
+      Member toMember,
+      AlarmType alarmType,
+      Long windowId,
+      Long objectId,
+      String alarmArgs) {
+    this.fromMember = fromMember;
+    this.toMember = toMember;
+    this.alarmType = alarmType;
+    this.windowId = windowId;
+    this.objectId = objectId;
+    this.alarmArgs = alarmArgs;
+  }
+
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/alarm/entity/AlarmType.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/alarm/entity/AlarmType.java
@@ -1,0 +1,16 @@
+package com.haejwo.tripcometrue.domain.alarm.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlarmType {
+
+  NEW_TRIP_RECORD_REVIEW("새 리뷰 알림"),
+  NEW_TRIP_RECORD_COMMENT("새 여행후기 댓글 알림"),
+  NEW_PLACE_REVIEW_COMMENT("새 여행지리뷰 댓글 알림"),
+  REVIEW_WRITE_REQUEST("리뷰 작성 요청 알림");
+
+  private final String message;
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/alarm/repository/AlarmRepository.java
@@ -1,0 +1,14 @@
+package com.haejwo.tripcometrue.domain.alarm.repository;
+
+import com.haejwo.tripcometrue.domain.alarm.entity.Alarm;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+
+  Page<Alarm> findAllByToMember(Member member, Pageable pageable);
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/alarm/service/AlarmService.java
@@ -1,0 +1,57 @@
+package com.haejwo.tripcometrue.domain.alarm.service;
+
+import com.haejwo.tripcometrue.domain.alarm.dto.response.AlarmResponseDto;
+import com.haejwo.tripcometrue.domain.alarm.entity.Alarm;
+import com.haejwo.tripcometrue.domain.alarm.entity.AlarmType;
+import com.haejwo.tripcometrue.domain.alarm.repository.AlarmRepository;
+import com.haejwo.tripcometrue.domain.member.entity.Member;
+import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AlarmService {
+
+  private final AlarmRepository alarmRepository;
+
+
+  public Page<AlarmResponseDto> getAlarms(PrincipalDetails principalDetails, Pageable pageable) {
+    Page<Alarm> alarms = alarmRepository.findAllByToMember(principalDetails.getMember(), pageable);
+    return alarms.map(AlarmResponseDto::fromEntity);
+  }
+
+  public void addAlarm(Member fromMember, Member toMember, AlarmType alarmType, Long windowId,
+      Long objectId) {
+    String alarmArgs = createAlarmArgs(fromMember.getMemberBase().getNickname(), alarmType);
+    Alarm alarm = Alarm.builder()
+        .fromMember(fromMember)
+        .toMember(toMember)
+        .alarmType(alarmType)
+        .windowId(windowId)
+        .objectId(objectId)
+        .alarmArgs(alarmArgs)
+        .build();
+    alarmRepository.save(alarm);
+  }
+
+  private String createAlarmArgs(String memberNickname, AlarmType alarmType) {
+    switch (alarmType) {
+      case NEW_TRIP_RECORD_REVIEW:
+        return memberNickname + "님이 여행 후기에 리뷰를 남기셨습니다.";
+      case NEW_TRIP_RECORD_COMMENT:
+        return memberNickname + "님이 여행후기에 댓글을 남기셨습니다.";
+      case NEW_PLACE_REVIEW_COMMENT:
+        return memberNickname + "님이 여행지리뷰에 댓글을 남기셨습니다.";
+      case REVIEW_WRITE_REQUEST:
+        return "여행 후기에 리뷰를 남겨주세요.";
+      default:
+        return "알림 타입이 지정되지 않았습니다.";
+    }
+  }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/placereview/service/PlaceReviewCommentService.java
@@ -1,5 +1,7 @@
 package com.haejwo.tripcometrue.domain.comment.placereview.service;
 
+import com.haejwo.tripcometrue.domain.alarm.entity.AlarmType;
+import com.haejwo.tripcometrue.domain.alarm.service.AlarmService;
 import com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto;
 import com.haejwo.tripcometrue.domain.comment.placereview.entity.PlaceReviewComment;
 import com.haejwo.tripcometrue.domain.comment.placereview.exception.PlaceReviewCommentNotFoundException;
@@ -28,6 +30,7 @@ public class PlaceReviewCommentService {
     private final MemberRepository memberRepository;
     private final PlaceReviewRepository placeReviewRepository;
     private final PlaceReviewCommentRepository placeReviewCommentRepository;
+    private final AlarmService alarmService;
 
     public void saveComment(
             PrincipalDetails principalDetails,
@@ -41,6 +44,13 @@ public class PlaceReviewCommentService {
         PlaceReviewComment comment = com.haejwo.tripcometrue.domain.comment.placereview.dto.request.PlaceReviewCommentRequestDto.toComment(loginMember, placeReview, requestDto);
         placeReviewCommentRepository.save(comment);
         placeReview.increaseCommentCount();
+
+        alarmService.addAlarm(
+            loginMember,
+            placeReview.getMember(),
+            AlarmType.NEW_PLACE_REVIEW_COMMENT,
+            placeReviewId,
+            comment.getId());
     }
 
     private Member getMember(PrincipalDetails principalDetails) {

--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/service/TripRecordCommentService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/service/TripRecordCommentService.java
@@ -1,5 +1,7 @@
 package com.haejwo.tripcometrue.domain.comment.triprecord.service;
 
+import com.haejwo.tripcometrue.domain.alarm.entity.AlarmType;
+import com.haejwo.tripcometrue.domain.alarm.service.AlarmService;
 import com.haejwo.tripcometrue.domain.comment.triprecord.dto.request.TripRecordCommentRequestDto;
 import com.haejwo.tripcometrue.domain.comment.triprecord.dto.response.TripRecordCommentListResponseDto;
 import com.haejwo.tripcometrue.domain.comment.triprecord.entity.TripRecordComment;
@@ -31,6 +33,7 @@ public class TripRecordCommentService {
     private final MemberRepository memberRepository;
     private final TripRecordRepository tripRecordRepository;
     private final TripRecordCommentRepository tripRecordCommentRepository;
+    private final AlarmService alarmService;
 
     public void saveComment(
             PrincipalDetails principalDetails,
@@ -44,6 +47,13 @@ public class TripRecordCommentService {
         TripRecordComment comment = TripRecordCommentRequestDto.toComment(loginMember, tripRecord, requestDto);
         tripRecordCommentRepository.save(comment);
         tripRecord.incrementCommentCount();
+
+        alarmService.addAlarm(
+            loginMember,
+            tripRecord.getMember(),
+            AlarmType.NEW_TRIP_RECORD_COMMENT,
+            tripRecordId,
+            comment.getId());
     }
 
     private Member getMember(PrincipalDetails principalDetails) {

--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/service/TripRecordReviewService.java
@@ -1,5 +1,7 @@
 package com.haejwo.tripcometrue.domain.review.triprecordreview.service;
 
+import com.haejwo.tripcometrue.domain.alarm.entity.AlarmType;
+import com.haejwo.tripcometrue.domain.alarm.service.AlarmService;
 import com.haejwo.tripcometrue.domain.likes.entity.TripRecordReviewLikes;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.member.exception.UserInvalidAccessException;
@@ -49,6 +51,7 @@ public class TripRecordReviewService {
     private final TripRecordRepository tripRecordRepository;
     private final MemberRepository memberRepository;
     private final TripPlanRepository tripPlanRepository;
+    private final AlarmService alarmService;
 
     // FIXME: 1/18/24 ratingScore @NotNull과 상충되는 부분 수정하기
     @Transactional
@@ -142,6 +145,13 @@ public class TripRecordReviewService {
         isReviewAlreadyRegister(tripRecordReview);
 
         tripRecordReview.registerContent(requestDto, loginMember);
+
+        alarmService.addAlarm(
+            loginMember,
+            tripRecordReview.getTripRecord().getMember(),
+            AlarmType.NEW_TRIP_RECORD_REVIEW,
+            tripRecordReview.getTripRecord().getId(),
+            tripRecordReviewId);
     }
 
     private void isReviewAlreadyRegister(TripRecordReview tripRecordReview) {
@@ -269,4 +279,6 @@ public class TripRecordReviewService {
                         hasLikedTripRecordReview(principalDetails, tripRecordReview))
                 ).toList());
     }
+
+
 }


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)
- [ ] 리팩토링 (Refactoring)
- [ ] 버그 수정 (Bug Fix)
- [ ] 테스트 (Test)
- [ ] CI/CD
- [ ] 설정 (Setup)

- **간략한 설명**:
  :  댓글/리뷰 작성에 대한 마이페이지 내부 알림 보관 리스트 기능 구현

---

## 🛠 작성/변경 사항

- 알림 테이블 생성 후 , 알림 트리거(여행후기 댓글, 여행지리뷰 댓글, 여행후기 리뷰) 상황 발생시 알림 데이터 저장
- 알림 트리거 상황에 따라 alarmType필드는 ENUM 활용하여 다르게 저장
- objectId(트리거 발생 대상객체id) 나 windowId(트리거 발생 대상객체가 포함된 위치 id) 는 도메인 구별없이 숫자로 응답값에 포함됨. 프론트 라우팅 보조용도로 사용
- alarmArgs 변수에 커스텀 메시지(댓글/리뷰 작성자)를 넣어서 반환
---

## 🔗 관련 이슈

- **이슈 링크1** : #68 

---

## 💡 특이 사항

- **주목할 사항** 
  - 이후 여행후기 리뷰 작성 조건 충족시 리뷰작성요청에 대한 알림 케이스 구현 필요
  - 알림기능 구현에 대한 다른 효과적인 방법이나 기술스택 검토 

---

