### PR TITLE
[fix] 로그인하지 않은 사용자도 여행 후기 댓글(TripRecordComment) 목록 조회 가능하도록 수정

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/service/TripRecordCommentService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/comment/triprecord/service/TripRecordCommentService.java
@@ -57,8 +57,11 @@ public class TripRecordCommentService {
     }
 
     private Member getMember(PrincipalDetails principalDetails) {
-        return memberRepository.findById(principalDetails.getMember().getId())
-                .orElseThrow(UserNotFoundException::new);
+        if (principalDetails != null) {
+            return memberRepository.findById(principalDetails.getMember().getId())
+                    .orElseThrow(UserNotFoundException::new);
+        }
+        return null;
     }
 
     public void saveReplyComment(


### PR DESCRIPTION
## 🎯 목적

- [x] 버그 수정 (Bug Fix)

- **간략한 설명**:
  : 로그인하지 않은 유저도 여행 후기 댓글을 조회할 수 있도록 수정했습니다.

---

## 🛠 작성/변경 사항

### - `PrincipalDetails`가 `null` 인 경우 생기는 오류를 수정했습니다. 
  - 로그인하지 않으면 PrincipalDetails가 null로 들어옵니다. null 값을 이용해 memberRepository에서 멤버를 찾는 과정에서 에러가 발생했기 때문에, if문을 통해 로그인 하지 않은 유저가 통과될 수 있도록 수정했습니다.
  ```java
  private Member getMember(PrincipalDetails principalDetails) {
      if (principalDetails != null) {
          return memberRepository.findById(principalDetails.getMember().getId())
                  .orElseThrow(UserNotFoundException::new);
      }
      return null;
  }
  ```
---

## 🔗 관련 이슈

- **이슈 링크1** : #9 
