### PR TITLE
[refactor] 홈/검색/도시 상세 피드 API 리팩토링 및 수정, 로그인한 사용자 '도시 보관' 여부 조회 API 구현

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/request/AddCityRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/request/AddCityRequestDto.java
@@ -1,7 +1,7 @@
 package com.haejwo.tripcometrue.domain.city.dto.request;
 
 import com.haejwo.tripcometrue.domain.city.entity.City;
-import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import com.haejwo.tripcometrue.global.enums.Country;
 
 public record AddCityRequestDto(

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/request/AddCityRequestDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/request/AddCityRequestDto.java
@@ -6,6 +6,7 @@ import com.haejwo.tripcometrue.global.enums.Country;
 
 public record AddCityRequestDto(
     String name,
+    String englishName,
     String language,
     String timeDifference,
     String voltage,
@@ -18,6 +19,7 @@ public record AddCityRequestDto(
     public City toEntity() {
         return City.builder()
             .name(this.name)
+            .englishName(this.englishName)
             .language(this.language)
             .timeDifference(this.timeDifference)
             .voltage(this.voltage)

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/dto/response/CityResponseDto.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 public record CityResponseDto(
     Long cityId,
     String name,
+    String englishName,
     String language,
     String timeDifference,
     String voltage,
@@ -28,6 +29,7 @@ public record CityResponseDto(
         return CityResponseDto.builder()
             .cityId(entity.getId())
             .name(entity.getName())
+            .englishName(entity.getEnglishName())
             .language(entity.getLanguage())
             .timeDifference(entity.getTimeDifference())
             .voltage(entity.getVoltage())
@@ -47,6 +49,7 @@ public record CityResponseDto(
         return CityResponseDto.builder()
             .cityId(entity.getId())
             .name(entity.getName())
+            .englishName(entity.getEnglishName())
             .language(entity.getLanguage())
             .timeDifference(entity.getTimeDifference())
             .voltage(entity.getVoltage())

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
@@ -19,6 +19,7 @@ public class City extends BaseTimeEntity {
     @Column(name = "city_id")
     private Long id;
     private String name;
+    private String englishName;
     private String language;
     private String timeDifference;
     private String voltage;
@@ -38,12 +39,13 @@ public class City extends BaseTimeEntity {
 
     @Builder
     private City(
-        Long id, String name, String language, String timeDifference,
+        Long id, String name, String englishName, String language, String timeDifference,
         String voltage, String visa, CurrencyUnit currency, String weatherRecommendation,
         String weatherDescription, Integer storeCount, Country country, String imageUrl
     ) {
         this.id = id;
         this.name = name;
+        this.englishName = englishName;
         this.language = language;
         this.timeDifference = timeDifference;
         this.voltage = voltage;

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/entity/City.java
@@ -2,6 +2,7 @@ package com.haejwo.tripcometrue.domain.city.entity;
 
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
 import com.haejwo.tripcometrue.global.enums.Country;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityInfoReadService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/CityInfoReadService.java
@@ -4,7 +4,7 @@ import com.haejwo.tripcometrue.domain.city.dto.response.CityInfoResponseDto;
 import com.haejwo.tripcometrue.domain.city.dto.response.ExchangeRateResponseDto;
 import com.haejwo.tripcometrue.domain.city.dto.response.WeatherResponseDto;
 import com.haejwo.tripcometrue.domain.city.entity.City;
-import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import com.haejwo.tripcometrue.domain.city.entity.Weather;
 import com.haejwo.tripcometrue.domain.city.exception.CityNotFoundException;
 import com.haejwo.tripcometrue.domain.city.repository.CityRepository;

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/CitySearchService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/CitySearchService.java
@@ -2,7 +2,7 @@ package com.haejwo.tripcometrue.domain.city.service;
 
 import com.haejwo.tripcometrue.domain.city.dto.response.CityResponseDto;
 import com.haejwo.tripcometrue.domain.city.entity.City;
-import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/src/main/java/com/haejwo/tripcometrue/domain/city/service/ExchangeRateUpdateScheduler.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/city/service/ExchangeRateUpdateScheduler.java
@@ -1,7 +1,7 @@
 package com.haejwo.tripcometrue.domain.city.service;
 
 import com.haejwo.tripcometrue.domain.city.dto.api.ExchangeRateApiDto;
-import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepository.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaceRepository extends
-    JpaRepository<Place, Long>, PlaceCustomRepository
+    JpaRepository<Place, Long>, PlaceRepositoryCustom
 {
     List<Place> findByCityId(Long cityId);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryCustom.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
-public interface PlaceCustomRepository {
+public interface PlaceRepositoryCustom {
 
     Page<Place> findPlaceWithFilter(Pageable pageable,
                                     Integer storedCount);

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryImpl.java
@@ -72,7 +72,7 @@ public class PlaceRepositoryImpl extends QuerydslRepositorySupport implements Pl
         int pageSize = pageable.getPageSize();
         List<Place> content = queryFactory
             .selectFrom(place)
-            .join(place.city, city)
+            .innerJoin(place.city, city)
             .where(
                 city.id.eq(cityId),
                 containsIgnoreCasePlaceName(placeName)
@@ -97,7 +97,7 @@ public class PlaceRepositoryImpl extends QuerydslRepositorySupport implements Pl
         int pageSize = pageable.getPageSize();
         List<Place> content = queryFactory
             .selectFrom(place)
-            .join(place.city, city).fetchJoin()
+            .innerJoin(place.city, city).fetchJoin()
             .where(
                 containsIgnoreCasePlaceName(placeName)
             )
@@ -120,7 +120,7 @@ public class PlaceRepositoryImpl extends QuerydslRepositorySupport implements Pl
 
         return queryFactory
             .selectFrom(place)
-            .join(place.city)
+            .innerJoin(place.city)
             .where(place.city.eq(city))
             .orderBy(place.storedCount.desc(), place.createdAt.desc())
             .limit(size)
@@ -267,12 +267,11 @@ public class PlaceRepositoryImpl extends QuerydslRepositorySupport implements Pl
                     case "commentCount":
                         orderSpecifiers.add(new OrderSpecifier<>(direction, place.commentCount));
                         break;
-
-                    // TODO: 정렬 기준 예외 처리
                 }
             }
         }
 
+        // 아무 조건 존재하지 않는 경우, order by null
         if(orderSpecifiers.isEmpty()) {
             orderSpecifiers.add(new OrderSpecifier(Order.ASC, NullExpression.DEFAULT, NullHandling.Default));
         }

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryImpl.java
@@ -34,11 +34,11 @@ import org.springframework.util.StringUtils;
 import static com.haejwo.tripcometrue.domain.city.entity.QCity.city;
 import static com.haejwo.tripcometrue.domain.place.entity.QPlace.place;
 
-public class PlaceCustomRepositoryImpl extends QuerydslRepositorySupport implements PlaceCustomRepository {
+public class PlaceRepositoryImpl extends QuerydslRepositorySupport implements PlaceRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    public PlaceCustomRepositoryImpl(JPAQueryFactory queryFactory) {
+    public PlaceRepositoryImpl(JPAQueryFactory queryFactory) {
         super(Place.class);
         this.queryFactory = queryFactory;
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/repositroy/PlaceRepositoryImpl.java
@@ -72,7 +72,7 @@ public class PlaceRepositoryImpl extends QuerydslRepositorySupport implements Pl
         int pageSize = pageable.getPageSize();
         List<Place> content = queryFactory
             .selectFrom(place)
-            .innerJoin(place.city, city)
+            .join(place.city, city)
             .where(
                 city.id.eq(cityId),
                 containsIgnoreCasePlaceName(placeName)
@@ -97,7 +97,7 @@ public class PlaceRepositoryImpl extends QuerydslRepositorySupport implements Pl
         int pageSize = pageable.getPageSize();
         List<Place> content = queryFactory
             .selectFrom(place)
-            .innerJoin(place.city, city).fetchJoin()
+            .join(place.city, city).fetchJoin()
             .where(
                 containsIgnoreCasePlaceName(placeName)
             )
@@ -120,7 +120,7 @@ public class PlaceRepositoryImpl extends QuerydslRepositorySupport implements Pl
 
         return queryFactory
             .selectFrom(place)
-            .innerJoin(place.city)
+            .join(place.city)
             .where(place.city.eq(city))
             .orderBy(place.storedCount.desc(), place.createdAt.desc())
             .limit(size)

--- a/src/main/java/com/haejwo/tripcometrue/domain/place/service/PlaceService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/place/service/PlaceService.java
@@ -136,8 +136,6 @@ public class PlaceService {
         placeRepository.delete(findPlace);
     }
 
-
-
     private Place findPlaceById(Long placeId) {
 
         Place findPlace = placeRepository.findById(placeId)
@@ -145,7 +143,5 @@ public class PlaceService {
 
         return findPlace;
     }
-
-
 
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/controller/StoreController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/controller/StoreController.java
@@ -3,6 +3,7 @@ package com.haejwo.tripcometrue.domain.store.controller;
 import com.haejwo.tripcometrue.domain.store.dto.request.CityStoreRequestDto;
 import com.haejwo.tripcometrue.domain.store.dto.request.PlaceStoreRequestDto;
 import com.haejwo.tripcometrue.domain.store.dto.request.TripRecordStoreRequestDto;
+import com.haejwo.tripcometrue.domain.store.dto.response.CheckCityStoredResponseDto;
 import com.haejwo.tripcometrue.domain.store.dto.response.CityStoreResponseDto;
 import com.haejwo.tripcometrue.domain.store.dto.response.PlaceStoreResponseDto;
 import com.haejwo.tripcometrue.domain.store.dto.response.TripRecordStoreResponseDto;
@@ -115,5 +116,20 @@ public class StoreController {
     public ResponseEntity<ResponseDTO<Long>> getStoredCountForTripRecord(@PathVariable Long tripRecordId) {
         Long count = storeService.getStoredCountForTripRecord(tripRecordId);
         return ResponseEntity.ok(ResponseDTO.okWithData(count));
+    }
+
+    @GetMapping("/v1/cities/{cityId}/stores")
+    public ResponseEntity<ResponseDTO<CheckCityStoredResponseDto>> checkCityStoredByLoginMember(
+        @PathVariable("cityId") Long cityId,
+        @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+
+        return ResponseEntity
+            .ok()
+            .body(
+                ResponseDTO.okWithData(
+                    storeService.checkCityStoredByLoginMember(principalDetails, cityId)
+                )
+            );
     }
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/dto/response/CheckCityStoredResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/dto/response/CheckCityStoredResponseDto.java
@@ -1,0 +1,12 @@
+package com.haejwo.tripcometrue.domain.store.dto.response;
+
+import lombok.Builder;
+
+public record CheckCityStoredResponseDto(
+    boolean isStored
+) {
+
+    @Builder
+    public CheckCityStoredResponseDto {
+    }
+}

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/dto/response/CityStoreResponseDto.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/dto/response/CityStoreResponseDto.java
@@ -1,6 +1,6 @@
 package com.haejwo.tripcometrue.domain.store.dto.response;
 import com.haejwo.tripcometrue.domain.city.entity.City;
-import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import com.haejwo.tripcometrue.domain.store.entity.CityStore;
 import com.haejwo.tripcometrue.global.enums.Country;
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/entity/CityStore.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/entity/CityStore.java
@@ -1,23 +1,17 @@
 package com.haejwo.tripcometrue.domain.store.entity;
+
 import com.haejwo.tripcometrue.domain.city.entity.City;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class CityStore extends BaseTimeEntity {
 
     @Id
@@ -25,16 +19,16 @@ public class CityStore extends BaseTimeEntity {
     @Column(name = "city_store_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id")
     Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "city_id")
     City city;
 
     @Builder
-    public CityStore(Member member, City city){
+    private CityStore(Member member, City city){
         this.member = member;
         this.city = city;
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/entity/PlaceStore.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/entity/PlaceStore.java
@@ -1,23 +1,17 @@
 package com.haejwo.tripcometrue.domain.store.entity;
+
 import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.place.entity.Place;
 import com.haejwo.tripcometrue.global.entity.BaseTimeEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class PlaceStore extends BaseTimeEntity {
 
     @Id
@@ -25,16 +19,16 @@ public class PlaceStore extends BaseTimeEntity {
     @Column(name = "place_store_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id")
     Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "place_id")
     Place place;
 
     @Builder
-    public PlaceStore(Member member, Place place){
+    private PlaceStore(Member member, Place place){
         this.member = member;
         this.place = place;
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/entity/TripRecordStore.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/entity/TripRecordStore.java
@@ -11,13 +11,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 public class TripRecordStore extends BaseTimeEntity {
 
     @Id
@@ -25,16 +26,16 @@ public class TripRecordStore extends BaseTimeEntity {
     @Column(name = "trip_record_store_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_Id")
     Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "trip_record_id")
     TripRecord tripRecord;
 
     @Builder
-    public TripRecordStore(Member member, TripRecord tripRecord){
+    private TripRecordStore(Member member, TripRecord tripRecord){
         this.member = member;
         this.tripRecord = tripRecord;
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/store/service/StoreService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/store/service/StoreService.java
@@ -9,6 +9,7 @@ import com.haejwo.tripcometrue.domain.place.repositroy.PlaceRepository;
 import com.haejwo.tripcometrue.domain.store.dto.request.CityStoreRequestDto;
 import com.haejwo.tripcometrue.domain.store.dto.request.PlaceStoreRequestDto;
 import com.haejwo.tripcometrue.domain.store.dto.request.TripRecordStoreRequestDto;
+import com.haejwo.tripcometrue.domain.store.dto.response.CheckCityStoredResponseDto;
 import com.haejwo.tripcometrue.domain.store.dto.response.CityStoreResponseDto;
 import com.haejwo.tripcometrue.domain.store.dto.response.PlaceStoreResponseDto;
 import com.haejwo.tripcometrue.domain.store.dto.response.TripRecordStoreResponseDto;
@@ -30,6 +31,8 @@ import com.haejwo.tripcometrue.global.exception.ErrorCode;
 import com.haejwo.tripcometrue.global.springsecurity.PrincipalDetails;
 import jakarta.transaction.Transactional;
 import java.util.List;
+import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -141,6 +144,25 @@ public class StoreService{
         tripRecord.decrementStoreCount();
 
         tripRecordStoreRepository.delete(tripRecordStore);
+    }
+
+    public CheckCityStoredResponseDto checkCityStoredByLoginMember(PrincipalDetails principalDetails, Long cityId) {
+
+        if (Objects.isNull(principalDetails.getMember())) {
+            return CheckCityStoredResponseDto.builder()
+                .isStored(false)
+                .build();
+        }
+
+        Long memberId = principalDetails.getMember().getId();
+
+        return CheckCityStoredResponseDto.builder()
+            .isStored(
+                cityStoreRepository
+                    .findByMemberIdAndCityId(memberId, cityId)
+                    .isPresent()
+            )
+            .build();
     }
 
     public Page<CityStoreResponseDto> getStoredCities(PrincipalDetails principalDetails, Pageable pageable) {

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordController.java
@@ -124,7 +124,7 @@ public class TripRecordController {
 
     // 홈 피드 TOP 인기 여행 후기 리스트 조회
     @GetMapping("/top-list")
-    public ResponseEntity<ResponseDTO<List<TripRecordListItemResponseDto>>> tripRecordTopList(
+    public ResponseEntity<ResponseDTO<List<TripRecordListItemResponseDto>>> listTopTripRecords(
         @RequestParam("type") @HomeTopListQueryType String type
     ) {
         return ResponseEntity

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordScheduleVideoController.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/controller/TripRecordScheduleVideoController.java
@@ -21,7 +21,7 @@ public class TripRecordScheduleVideoController {
     private final TripRecordScheduleVideoService tripRecordScheduleVideoService;
 
     @GetMapping("/list")
-    public ResponseEntity<ResponseDTO<List<TripRecordScheduleVideoListItemResponseDto>>> getVideosByType(
+    public ResponseEntity<ResponseDTO<List<TripRecordScheduleVideoListItemResponseDto>>> listVideosByRequestType(
         @RequestParam("type") @HomeVideoListQueryType String type
     ) {
         return ResponseEntity

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepository.java
@@ -14,5 +14,6 @@ public interface TripRecordRepository extends
 {
 
   Page<TripRecord> findByMemberId(Long memberId, Pageable pageable);
-  Optional<TripRecord> findById (Member member);
+
+  Optional<TripRecord> findByMember(Member member);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripRecordRepository extends
     JpaRepository<TripRecord, Long>,
-    TripRecordCustomRepository
+    TripRecordRepositoryCustom
 
 {
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryCustom.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
-public interface TripRecordCustomRepository {
+public interface TripRecordRepositoryCustom {
 
     List<TripRecordListResponseDto> finTripRecordWithFilter(Pageable pageable, TripRecordListRequestAttribute request);
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryCustom.java
@@ -15,17 +15,17 @@ public interface TripRecordRepositoryCustom {
 
     List<TripRecordListResponseDto> finTripRecordWithFilter(Pageable pageable, TripRecordListRequestAttribute request);
 
-    Slice<TripRecord> findTripRecordListByFilter(TripRecordSearchParamAttribute requestParamAttribute, Pageable pageable);
+    Slice<TripRecord> findTripRecordsByFilter(TripRecordSearchParamAttribute requestParamAttribute, Pageable pageable);
 
     Slice<TripRecord> findTripRecordsByHashtag(String hashTag, Pageable pageable);
 
     Slice<TripRecord> findTripRecordsByExpenseRangeType(ExpenseRangeType expenseRangeType, Pageable pageable);
 
-    List<TripRecord> findTopTripRecordListDomestic(int size);
+    List<TripRecord> findTopTripRecordsDomestic(int size);
 
-    List<TripRecord> findTopTripRecordListOverseas(int size);
+    List<TripRecord> findTopTripRecordsOverseas(int size);
 
     List<TripRecordHotShortsListResponseDto> findTripRecordHotShortsList(Pageable pageable);
 
-    List<TripRecord> findTripRecordListWithMemberInMemberIds(List<Long> memberIds);
+    List<TripRecord> findTripRecordsWithMemberInMemberIds(List<Long> memberIds);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryImpl.java
@@ -134,7 +134,7 @@ public class TripRecordRepositoryImpl extends QuerydslRepositorySupport implemen
     }
 
     @Override
-    public Slice<TripRecord> findTripRecordListByFilter(
+    public Slice<TripRecord> findTripRecordsByFilter(
         TripRecordSearchParamAttribute requestParamAttribute,
         Pageable pageable
     ) {
@@ -233,7 +233,7 @@ public class TripRecordRepositoryImpl extends QuerydslRepositorySupport implemen
     }
 
     @Override
-    public List<TripRecord> findTopTripRecordListDomestic(int size) {
+    public List<TripRecord> findTopTripRecordsDomestic(int size) {
 
         return queryFactory
             .selectFrom(tripRecord)
@@ -244,7 +244,7 @@ public class TripRecordRepositoryImpl extends QuerydslRepositorySupport implemen
     }
 
     @Override
-    public List<TripRecord> findTopTripRecordListOverseas(int size) {
+    public List<TripRecord> findTopTripRecordsOverseas(int size) {
 
         return queryFactory
             .selectFrom(tripRecord)
@@ -297,7 +297,7 @@ public class TripRecordRepositoryImpl extends QuerydslRepositorySupport implemen
     }
 
     @Override
-    public List<TripRecord> findTripRecordListWithMemberInMemberIds(List<Long> memberIds) {
+    public List<TripRecord> findTripRecordsWithMemberInMemberIds(List<Long> memberIds) {
 
         return queryFactory.selectFrom(tripRecord)
             .join(tripRecord.member, member).fetchJoin()

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryImpl.java
@@ -383,12 +383,11 @@ public class TripRecordRepositoryImpl extends QuerydslRepositorySupport implemen
                     case "averageRating":
                         orderSpecifiers.add(new OrderSpecifier<>(direction, tripRecord.averageRating));
                         break;
-
-                    // TODO: 정렬 기준 예외 처리
                 }
             }
         }
 
+        // 정렬 기준 없는 경우 order by null
         if(orderSpecifiers.isEmpty()) {
             orderSpecifiers.add(new OrderSpecifier(Order.ASC, NullExpression.DEFAULT, NullHandling.Default));
         }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord/TripRecordRepositoryImpl.java
@@ -37,11 +37,11 @@ import static com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecord.tripR
 import static com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordSchedule.tripRecordSchedule;
 import static com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordTag.tripRecordTag;
 
-public class TripRecordCustomRepositoryImpl extends QuerydslRepositorySupport implements TripRecordCustomRepository {
+public class TripRecordRepositoryImpl extends QuerydslRepositorySupport implements TripRecordRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    public TripRecordCustomRepositoryImpl(JPAQueryFactory queryFactory) {
+    public TripRecordRepositoryImpl(JPAQueryFactory queryFactory) {
         super(TripRecord.class);
         this.queryFactory = queryFactory;
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TripRecordScheduleRepository extends
     JpaRepository<TripRecordSchedule, Long>,
-    TripRecordScheduleCustomRepository {
+    TripRecordScheduleRepositoryCustom {
 
 
     List<TripRecordSchedule> findAllByTripRecordId(Long recordId);

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepositoryCustom.java
@@ -5,7 +5,7 @@ import com.haejwo.tripcometrue.domain.triprecord.dto.response.triprecord_schedul
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface TripRecordScheduleCustomRepository {
+public interface TripRecordScheduleRepositoryCustom {
 
     Page<TripRecordScheduleImageListResponseDto> findScheduleImagesWithFilter(Pageable pageable, TripRecordScheduleImageListRequestAttribute request);
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule/TripRecordScheduleRepositoryImpl.java
@@ -19,12 +19,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class TripRecordScheduleCustomRepositoryImpl implements TripRecordScheduleCustomRepository {
+public class TripRecordScheduleRepositoryImpl implements TripRecordScheduleRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Autowired
-    public TripRecordScheduleCustomRepositoryImpl(EntityManager entityManager) {
+    public TripRecordScheduleRepositoryImpl(EntityManager entityManager) {
         this.jpaQueryFactory = new JPAQueryFactory(entityManager);
     }
 

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_image/TripRecordScheduleImageRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_image/TripRecordScheduleImageRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Sort;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.haejwo.tripcometrue.domain.city.entity.QCity.city;
 import static com.haejwo.tripcometrue.domain.place.entity.QPlace.place;
 import static com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordSchedule.tripRecordSchedule;
 import static com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecordScheduleImage.tripRecordScheduleImage;
@@ -30,10 +31,11 @@ public class TripRecordScheduleImageRepositoryImpl implements TripRecordSchedule
         int pageSize = pageable.getPageSize();
         List<TripRecordScheduleImage> content = queryFactory
             .selectFrom(tripRecordScheduleImage)
-            .leftJoin(tripRecordScheduleImage.tripRecordSchedule, tripRecordSchedule).fetchJoin()
-            .leftJoin(tripRecordSchedule.place, place)
+            .join(tripRecordScheduleImage.tripRecordSchedule, tripRecordSchedule).fetchJoin()
+            .join(tripRecordSchedule.place, place)
+            .join(place.city, city)
             .where(
-                place.city.id.eq(cityId)
+                city.id.eq(cityId)
             )
             .orderBy(getSort(pageable))
             .offset(pageable.getOffset())
@@ -53,10 +55,11 @@ public class TripRecordScheduleImageRepositoryImpl implements TripRecordSchedule
     public List<TripRecordScheduleImage> findByCityIdOrderByCreatedAtDescLimitSize(Long cityId, Integer size) {
         return queryFactory
             .selectFrom(tripRecordScheduleImage)
-            .leftJoin(tripRecordScheduleImage.tripRecordSchedule, tripRecordSchedule).fetchJoin()
-            .leftJoin(tripRecordSchedule.place, place)
+            .join(tripRecordScheduleImage.tripRecordSchedule, tripRecordSchedule).fetchJoin()
+            .join(tripRecordSchedule.place, place)
+            .join(place.city, city)
             .where(
-                place.city.id.eq(cityId)
+                city.id.eq(cityId)
             )
             .orderBy(tripRecordScheduleImage.createdAt.desc())
             .limit(size)
@@ -76,7 +79,8 @@ public class TripRecordScheduleImageRepositoryImpl implements TripRecordSchedule
             )
             .from(tripRecordScheduleImage)
             .join(tripRecordScheduleImage.tripRecordSchedule, tripRecordSchedule)
-            .where(tripRecordSchedule.place.id.in(placeIds))
+            .join(tripRecordSchedule.place, place)
+            .where(place.id.in(placeIds))
             .orderBy(tripRecordScheduleImage.createdAt.desc())
             .fetch();
     }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryCustom.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryCustom.java
@@ -12,11 +12,11 @@ public interface TripRecordScheduleVideoRepositoryCustom {
 
     List<TripRecordScheduleVideoQueryDto> findByCityIdOrderByCreatedAtDescLimitSize(Long cityId, Integer size);
 
-    List<TripRecordScheduleVideoQueryDto> findNewestVideoList(int size);
+    List<TripRecordScheduleVideoQueryDto> findNewestVideos(int size);
 
-    List<TripRecordScheduleVideoQueryDto> findNewestVideoListDomestic(int size);
+    List<TripRecordScheduleVideoQueryDto> findNewestVideosDomestic(int size);
 
-    List<TripRecordScheduleVideoQueryDto> findNewestVideoListOverseas(int size);
+    List<TripRecordScheduleVideoQueryDto> findNewestVideosOverseas(int size);
 
-    List<TripRecordScheduleVideoQueryDto> findVideoListInMemberIds(List<Long> memberIds);
+    List<TripRecordScheduleVideoQueryDto> findInMemberIds(List<Long> memberIds);
 }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Sort;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.haejwo.tripcometrue.domain.city.entity.QCity.city;
 import static com.haejwo.tripcometrue.domain.member.entity.QMember.member;
 import static com.haejwo.tripcometrue.domain.place.entity.QPlace.place;
 import static com.haejwo.tripcometrue.domain.triprecord.entity.QTripRecord.tripRecord;
@@ -48,10 +49,11 @@ public class TripRecordScheduleVideoRepositoryImpl implements TripRecordSchedule
             .from(tripRecordScheduleVideo)
             .join(tripRecordScheduleVideo.tripRecordSchedule, tripRecordSchedule)
             .join(tripRecordSchedule.place, place)
+            .join(place.city, city)
             .join(tripRecordSchedule.tripRecord, tripRecord)
             .join(tripRecord.member, member)
             .where(
-                place.city.id.eq(cityId)
+                city.id.eq(cityId)
             )
             .orderBy(getSort(pageable))
             .offset(pageable.getOffset())
@@ -87,10 +89,11 @@ public class TripRecordScheduleVideoRepositoryImpl implements TripRecordSchedule
             .from(tripRecordScheduleVideo)
             .join(tripRecordScheduleVideo.tripRecordSchedule, tripRecordSchedule)
             .join(tripRecordSchedule.place, place)
+            .join(place.city, city)
             .join(tripRecordSchedule.tripRecord, tripRecord)
             .join(tripRecord.member, member)
             .where(
-                place.city.id.eq(cityId)
+                city.id.eq(cityId)
             )
             .limit(size)
             .fetch();
@@ -218,7 +221,7 @@ public class TripRecordScheduleVideoRepositoryImpl implements TripRecordSchedule
                     case "createdAt":
                         return new OrderSpecifier[] {new OrderSpecifier<>(direction, tripRecordScheduleVideo.createdAt)};
                     case "storedCount":
-                        return new OrderSpecifier[] {new OrderSpecifier<>(direction, tripRecordSchedule.tripRecord.storeCount), newest};
+                        return new OrderSpecifier[] {new OrderSpecifier<>(direction, tripRecord.storeCount), newest};
                 }
             }
         }

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryImpl.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryImpl.java
@@ -97,7 +97,7 @@ public class TripRecordScheduleVideoRepositoryImpl implements TripRecordSchedule
     }
 
     @Override
-    public List<TripRecordScheduleVideoQueryDto> findNewestVideoList(int size) {
+    public List<TripRecordScheduleVideoQueryDto> findNewestVideos(int size) {
         return queryFactory
             .select(
                 Projections.constructor(
@@ -123,7 +123,7 @@ public class TripRecordScheduleVideoRepositoryImpl implements TripRecordSchedule
     }
 
     @Override
-    public List<TripRecordScheduleVideoQueryDto> findNewestVideoListDomestic(int size) {
+    public List<TripRecordScheduleVideoQueryDto> findNewestVideosDomestic(int size) {
         return queryFactory
             .select(
                 Projections.constructor(
@@ -150,7 +150,7 @@ public class TripRecordScheduleVideoRepositoryImpl implements TripRecordSchedule
     }
 
     @Override
-    public List<TripRecordScheduleVideoQueryDto> findNewestVideoListOverseas(int size) {
+    public List<TripRecordScheduleVideoQueryDto> findNewestVideosOverseas(int size) {
         return queryFactory
             .select(
                 Projections.constructor(
@@ -177,7 +177,7 @@ public class TripRecordScheduleVideoRepositoryImpl implements TripRecordSchedule
     }
 
     @Override
-    public List<TripRecordScheduleVideoQueryDto> findVideoListInMemberIds(List<Long> memberIds) {
+    public List<TripRecordScheduleVideoQueryDto> findInMemberIds(List<Long> memberIds) {
         return queryFactory
             .select(
                 Projections.constructor(

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordScheduleVideoService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordScheduleVideoService.java
@@ -23,11 +23,11 @@ public class TripRecordScheduleVideoService {
         List<TripRecordScheduleVideoQueryDto> queryResults;
 
         if (type.equalsIgnoreCase("all")) {
-            queryResults = tripRecordScheduleVideoRepository.findNewestVideoList(HOME_CONTENT_SIZE);
+            queryResults = tripRecordScheduleVideoRepository.findNewestVideos(HOME_CONTENT_SIZE);
         } else if (type.equalsIgnoreCase("domestic")) {
-            queryResults = tripRecordScheduleVideoRepository.findNewestVideoListDomestic(HOME_CONTENT_SIZE);
+            queryResults = tripRecordScheduleVideoRepository.findNewestVideosDomestic(HOME_CONTENT_SIZE);
         } else {
-            queryResults = tripRecordScheduleVideoRepository.findNewestVideoListOverseas(HOME_CONTENT_SIZE);
+            queryResults = tripRecordScheduleVideoRepository.findNewestVideosOverseas(HOME_CONTENT_SIZE);
         }
 
         return queryResults.stream()
@@ -39,7 +39,7 @@ public class TripRecordScheduleVideoService {
     public List<TripRecordScheduleVideoListItemResponseDto> getVideosInMemberIds(List<Long> memberIds) {
 
         return tripRecordScheduleVideoRepository
-            .findVideoListInMemberIds(memberIds)
+            .findInMemberIds(memberIds)
             .stream()
             .map(TripRecordScheduleVideoListItemResponseDto::fromQueryDto)
             .toList();

--- a/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/triprecord/service/TripRecordService.java
@@ -86,7 +86,7 @@ public class TripRecordService {
         Pageable pageable
     ) {
         return SliceResponseDto.of(
-            tripRecordRepository.findTripRecordListByFilter(searchParamAttribute, pageable)
+            tripRecordRepository.findTripRecordsByFilter(searchParamAttribute, pageable)
                 .map(tripRecord -> TripRecordListItemResponseDto.fromEntity(tripRecord, null, tripRecord.getMember()))
         );
     }
@@ -116,9 +116,9 @@ public class TripRecordService {
 
         List<TripRecord> tripRecords;
         if (type.equalsIgnoreCase("domestic")) {
-            tripRecords = tripRecordRepository.findTopTripRecordListDomestic(HOME_CONTENT_SIZE);
+            tripRecords = tripRecordRepository.findTopTripRecordsDomestic(HOME_CONTENT_SIZE);
         } else {
-            tripRecords = tripRecordRepository.findTopTripRecordListOverseas(HOME_CONTENT_SIZE);
+            tripRecords = tripRecordRepository.findTopTripRecordsOverseas(HOME_CONTENT_SIZE);
         }
 
         return tripRecords
@@ -141,7 +141,7 @@ public class TripRecordService {
     public List<TripRecordListItemResponseDto> findTripRecordsWihMemberInMemberIds(List<Long> memberIds) {
 
         return tripRecordRepository
-            .findTripRecordListWithMemberInMemberIds(memberIds)
+            .findTripRecordsWithMemberInMemberIds(memberIds)
             .stream()
             .map(tripRecord -> TripRecordListItemResponseDto.fromEntity(tripRecord, null, tripRecord.getMember()))
             .toList();

--- a/src/main/java/com/haejwo/tripcometrue/global/enums/CurrencyUnit.java
+++ b/src/main/java/com/haejwo/tripcometrue/global/enums/CurrencyUnit.java
@@ -1,4 +1,4 @@
-package com.haejwo.tripcometrue.domain.city.entity;
+package com.haejwo.tripcometrue.global.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/haejwo/tripcometrue/domain/city/repository/WeatherRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/city/repository/WeatherRepositoryTest.java
@@ -2,7 +2,7 @@ package com.haejwo.tripcometrue.domain.city.repository;
 
 import com.haejwo.tripcometrue.config.TestQuerydslConfig;
 import com.haejwo.tripcometrue.domain.city.entity.City;
-import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import com.haejwo.tripcometrue.domain.city.entity.Weather;
 import com.haejwo.tripcometrue.global.enums.Country;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/com/haejwo/tripcometrue/domain/city/service/CityInfoReadServiceTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/city/service/CityInfoReadServiceTest.java
@@ -5,7 +5,7 @@ import com.haejwo.tripcometrue.config.DatabaseCleanUpAfterEach;
 import com.haejwo.tripcometrue.domain.city.dto.response.CityInfoResponseDto;
 import com.haejwo.tripcometrue.domain.city.dto.response.WeatherResponseDto;
 import com.haejwo.tripcometrue.domain.city.entity.City;
-import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import com.haejwo.tripcometrue.domain.city.entity.Weather;
 import com.haejwo.tripcometrue.domain.city.exception.CityNotFoundException;
 import com.haejwo.tripcometrue.domain.city.repository.CityRepository;

--- a/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_image/TripRecordScheduleImageRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_image/TripRecordScheduleImageRepositoryTest.java
@@ -2,7 +2,7 @@ package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule
 
 import com.haejwo.tripcometrue.config.TestQuerydslConfig;
 import com.haejwo.tripcometrue.domain.city.entity.City;
-import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.member.repository.MemberRepository;

--- a/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
@@ -2,7 +2,7 @@ package com.haejwo.tripcometrue.domain.triprecord.repository.triprecord_schedule
 
 import com.haejwo.tripcometrue.config.TestQuerydslConfig;
 import com.haejwo.tripcometrue.domain.city.entity.City;
-import com.haejwo.tripcometrue.domain.city.entity.CurrencyUnit;
+import com.haejwo.tripcometrue.global.enums.CurrencyUnit;
 import com.haejwo.tripcometrue.domain.city.repository.CityRepository;
 import com.haejwo.tripcometrue.domain.member.entity.Member;
 import com.haejwo.tripcometrue.domain.member.repository.MemberRepository;

--- a/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
+++ b/src/test/java/com/haejwo/tripcometrue/domain/triprecord/repository/triprecord_schedule_video/TripRecordScheduleVideoRepositoryTest.java
@@ -296,7 +296,7 @@ class TripRecordScheduleVideoRepositoryTest {
         int size = 5;
 
         //when
-        List<TripRecordScheduleVideoQueryDto> result = tripRecordScheduleVideoRepository.findNewestVideoList(size);
+        List<TripRecordScheduleVideoQueryDto> result = tripRecordScheduleVideoRepository.findNewestVideos(size);
 
         //then
         assertThat(result).hasSize(size);
@@ -310,7 +310,7 @@ class TripRecordScheduleVideoRepositoryTest {
         int size = 5;
 
         //when
-        List<TripRecordScheduleVideoQueryDto> result = tripRecordScheduleVideoRepository.findNewestVideoListDomestic(size);
+        List<TripRecordScheduleVideoQueryDto> result = tripRecordScheduleVideoRepository.findNewestVideosDomestic(size);
 
         //then
         assertThat(result).hasSize(2);
@@ -322,7 +322,7 @@ class TripRecordScheduleVideoRepositoryTest {
         int size = 5;
 
         //when
-        List<TripRecordScheduleVideoQueryDto> result = tripRecordScheduleVideoRepository.findNewestVideoListOverseas(size);
+        List<TripRecordScheduleVideoQueryDto> result = tripRecordScheduleVideoRepository.findNewestVideosOverseas(size);
 
         //then
         assertThat(result).hasSize(4);


### PR DESCRIPTION
## 🎯 목적

- [x] 새 기능 (New Feature)
- [x] 리팩토링 (Refactoring)

- **간략한 설명**:
  :  홈/검색/도시 상세 피드 API 리팩토링 및 수정 + 로그인한 사용자 '도시 보관' 여부 조회 API 구현

---

## 🛠 작성/변경 사항

- ### **(주요작성/변경사항)**
   - Repository 클래스명 통일 수정 , 메서드명 수정
   - 보관 관련 ~Store 엔티티 수정 리팩토링
   - Querydsl 동적 쿼리 암묵적 join --> 명시적 join 으로 수정
   - 프론트 요청에 따라 City 엔티티 '도시 영문명' 필드 추가
   - 로그인한 사용자 '도시 보관' 여부 조회 API 구현

---

## 🔗 관련 이슈

- **이슈 링크** : #127 

---

This close #127 