### PR TITLE
[fix] 최신 여행 후기 totalCount 조회에서 여행 후기id에 따라 개수 변화 기능 수정

### DIFF
--- a/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/repository/TripRecordReviewRepository.java
+++ b/src/main/java/com/haejwo/tripcometrue/domain/review/triprecordreview/repository/TripRecordReviewRepository.java
@@ -26,6 +26,6 @@ public interface TripRecordReviewRepository extends JpaRepository<TripRecordRevi
 
     boolean existsByMemberAndTripRecord(Member member, TripRecord tripRecord);
 
-    @Query("select count(trr) from TripRecordReview trr where trr.content is not null")
-    Long countByTripRecordId(Long tripRecordId);
+    @Query("select count(trr) from TripRecordReview trr where trr.content is not null and trr.tripRecord.id = :tripRecordId")
+    Long countByTripRecordId(@Param("tripRecordId") Long tripRecordId);
 }


### PR DESCRIPTION
## 🎯 목적

- [x] 버그 수정 (Bug Fix)

- **간략한 설명**:
  : 최신 여행 후기를 조회했을 때 여행 후기 id에 따라 조회 totalCount가 통일되서 나오는 문제 해결

---

## 🛠 작성/변경 사항

- 리포지토리에 Query문에서 여행 후기 id where 조건문에 추가


